### PR TITLE
nginx-util: use uci for server configuraton

### DIFF
--- a/net/nginx-util/Makefile
+++ b/net/nginx-util/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx-util
-PKG_VERSION:=1.3
-PKG_RELEASE:=2
+PKG_VERSION:=1.4
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
 
 include $(INCLUDE_DIR)/package.mk
@@ -11,18 +11,21 @@ include $(INCLUDE_DIR)/cmake.mk
 CMAKE_OPTIONS+= -DUBUS=y
 CMAKE_OPTIONS+= -DVERSION=$(PKG_VERSION)
 
+
 define Package/nginx-util/default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=Nginx configurator
-  DEPENDS:=+libstdcpp +libubus +libubox +libpthread
+  DEPENDS:=+libstdcpp +libuci +libubus +libubox +libpthread
 endef
+
 
 define Package/nginx-util
   $(Package/nginx-util/default)
   CONFLICTS:=nginx-ssl-util-nopcre nginx-ssl-util
 endef
+
 
 define Package/nginx-ssl-util/default
   $(Package/nginx-util/default)
@@ -31,6 +34,7 @@ define Package/nginx-ssl-util/default
   CONFLICTS:=,nginx-util
 endef
 
+
 define Package/nginx-ssl-util
   $(Package/nginx-ssl-util/default)
   TITLE+= (using PCRE)
@@ -38,43 +42,94 @@ define Package/nginx-ssl-util
   CONFLICTS+= ,nginx-ssl-util-nopcre
 endef
 
+
 define Package/nginx-ssl-util-nopcre
   $(Package/nginx-ssl-util/default)
   TITLE+= (using <regex>)
   CONFLICTS+= nginx-ssl-util
 endef
 
+
 define Package/nginx-util/description
   Utility that builds dynamically LAN listen directives for Nginx.
 endef
+
 
 Package/nginx-ssl-util/default/description = $(Package/nginx-util/description)\
   Furthermore, it manages SSL directives for its server parts and can create \
   corresponding (self-signed) certificates.
 
+
 Package/nginx-ssl-util/description = \
   $(Package/nginx-ssl-util/default/description) \
   It uses the PCRE library for performance.
+
 
 Package/nginx-ssl-util-nopcre/description = \
   $(Package/nginx-ssl-util/default/description) \
   It uses the standard regex library of C++.
 
+
 define Package/nginx-util/install
+	$(INSTALL_DIR) $(1)/etc/nginx/conf.d/
+	$(INSTALL_CONF) ./files/_uci.conf $(1)/etc/nginx/conf.d/
+
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) ./files/config-nginx $(1)/etc/config/nginx
+
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nginx-util $(1)/usr/bin/nginx-util
 endef
 
+
+define Package/nginx-ssl-util/install/default
+	$(INSTALL_DIR) $(1)/etc/nginx/conf.d/
+	$(INSTALL_CONF) ./files/_uci.conf $(1)/etc/nginx/conf.d/
+
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) ./files/config-nginx-ssl $(1)/etc/config/nginx
+
+ifneq ($(CONFIG_IPV6),y)
+	$(SED) "/listen\s*'\[/d" $(1)/etc/config/nginx # without IPv6 [::]
+endif
+endef
+
+
 define Package/nginx-ssl-util/install
+	$(call Package/nginx-ssl-util/install/default, $(1))
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nginx-ssl-util $(1)/usr/bin/nginx-util
 endef
 
+
 define Package/nginx-ssl-util-nopcre/install
+	$(call Package/nginx-ssl-util/install/default, $(1))
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nginx-ssl-util-nopcre \
 		$(1)/usr/bin/nginx-util
 endef
+
+
+define Package/nginx-ssl-util/prerm
+#!/bin/sh
+[ -z "$${IPKG_INSTROOT}" ] && exit 0
+[ "$${PKG_UPGRADE}" = "1" ] && exit 0
+
+eval "$$(/usr/bin/nginx-util get_env)"
+
+case "$$(/sbin/uci get "nginx.$${LAN_NAME}.$${MANAGE_SSL}" 2>/dev/null)" in
+	1|on|true|yes|enabled)
+		rm -f "$${CONF_DIR}$${LAN_NAME}.crt"
+		rm -f "$${CONF_DIR}$${LAN_NAME}.key"
+		;;
+esac
+
+exit 0
+endef
+
+
+Package/nginx-ssl-util-nopcre/prerm = $(Package/nginx-ssl-util/prerm)
+
 
 $(eval $(call BuildPackage,nginx-util))
 $(eval $(call BuildPackage,nginx-ssl-util))

--- a/net/nginx-util/files/_uci.conf
+++ b/net/nginx-util/files/_uci.conf
@@ -1,0 +1,2 @@
+# Do not delete this file (it will be reinstalled). For disabling, remove the following line:
+include /var/lib/nginx/*.conf

--- a/net/nginx-util/files/config-nginx
+++ b/net/nginx-util/files/config-nginx
@@ -1,0 +1,6 @@
+
+config server '_lan'
+	list listen_locally '80 default_server'
+	option server_name '_lan'
+	list include 'conf.d/*.locations'
+	option access_log 'off; # logd openwrt'

--- a/net/nginx-util/files/config-nginx-ssl
+++ b/net/nginx-util/files/config-nginx-ssl
@@ -1,0 +1,18 @@
+
+config server '_lan'
+	list listen_locally '443 ssl default_server'
+	option server_name '_lan'
+	list include 'conf.d/*.locations'
+	option manage_selfsigned 'true'
+	option ssl_certificate '/etc/nginx/conf.d/_lan.crt'
+	option ssl_certificate_key '/etc/nginx/conf.d/_lan.key'
+	option ssl_session_cache 'shared:SSL:32k'
+	option ssl_session_timeout '64m'
+	option access_log 'off; # logd openwrt'
+
+config server '_redirect2ssl'
+	list listen_locally '80'
+	list listen '80'
+	list listen '[::]:80'
+	option server_name '_redirect2ssl'
+	option return '302 https://$host$request_uri'

--- a/net/nginx-util/src/CMakeLists.txt
+++ b/net/nginx-util/src/CMakeLists.txt
@@ -7,13 +7,20 @@ INCLUDE(CheckFunctionExists)
 
 IF(UBUS)
 FIND_PATH(ubus_include_dir libubus.h)
-FIND_LIBRARY(ubox NAMES ubox)
 FIND_LIBRARY(ubus NAMES ubus)
 INCLUDE_DIRECTORIES(${ubus_include_dir})
 ENDIF()
 
+FIND_PATH(ubox_include_dir libubox/blobmsg.h)
+FIND_LIBRARY(ubox NAMES ubox)
+INCLUDE_DIRECTORIES(${ubox_include_dir})
+
+FIND_PATH(uci_include_dir uci.h)
+FIND_LIBRARY(uci NAMES uci)
+INCLUDE_DIRECTORIES(${uci_include_dir})
+
 ADD_DEFINITIONS(-Os -Wall -Werror -Wextra -g3)
-ADD_DEFINITIONS(-Wno-unused-parameter -Wmissing-declarations)
+ADD_DEFINITIONS(-Wno-unused-parameter -Wmissing-declarations -Wshadow)
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 
@@ -24,19 +31,21 @@ ADD_COMPILE_DEFINITIONS(VERSION=${VERSION})
 
 ADD_EXECUTABLE(nginx-util nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-util PUBLIC -DNO_SSL)
-TARGET_LINK_LIBRARIES(nginx-util ${ubox} ${ubus} pthread)
+TARGET_LINK_LIBRARIES(nginx-util ${uci} ${ubox} ${ubus} pthread)
 INSTALL(TARGETS nginx-util RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util nginx-util.cpp)
-TARGET_LINK_LIBRARIES(nginx-ssl-util ${ubox} ${ubus} pthread ssl crypto pcre)
+TARGET_LINK_LIBRARIES(nginx-ssl-util ${uci} ${ubox} ${ubus} pthread ssl crypto pcre)
 INSTALL(TARGETS nginx-ssl-util RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util-nopcre nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-ssl-util-nopcre PUBLIC -DNO_PCRE)
-TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre ${ubox} ${ubus} pthread ssl crypto)
+TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre ${uci} ${ubox} ${ubus} pthread ssl crypto)
 INSTALL(TARGETS nginx-ssl-util-nopcre RUNTIME DESTINATION bin)
 
 ELSE()
+
+ADD_COMPILE_DEFINITIONS(VERSION=0)
 
 CONFIGURE_FILE(test-px5g.sh test-px5g.sh COPYONLY)
 CONFIGURE_FILE(test-nginx-util.sh test-nginx-util.sh COPYONLY)
@@ -48,12 +57,12 @@ INSTALL(TARGETS px5g RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util-noubus nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-ssl-util-noubus PUBLIC -DNO_UBUS)
-TARGET_LINK_LIBRARIES(nginx-ssl-util-noubus pthread ssl crypto pcre)
+TARGET_LINK_LIBRARIES(nginx-ssl-util-noubus ${uci} ${ubox} pthread ssl crypto pcre)
 INSTALL(TARGETS nginx-ssl-util-noubus RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util-nopcre-noubus nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-ssl-util-nopcre-noubus PUBLIC -DNO_PCRE -DNO_UBUS)
-TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre-noubus pthread ssl crypto)
+TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre-noubus ${uci} ${ubox} pthread ssl crypto)
 INSTALL(TARGETS nginx-ssl-util-nopcre-noubus RUNTIME DESTINATION bin)
 
 ENDIF()

--- a/net/nginx-util/src/nginx-ssl-util.hpp
+++ b/net/nginx-util/src/nginx-ssl-util.hpp
@@ -1,8 +1,6 @@
 #ifndef __NGINX_SSL_UTIL_HPP
 #define __NGINX_SSL_UTIL_HPP
 
-#include <thread>
-
 #ifdef NO_PCRE
 #include <regex>
 namespace rgx = std;
@@ -24,7 +22,7 @@ static constexpr auto CRON_INTERVAL = std::string_view{"3 3 12 12 *"};
 static constexpr auto LAN_SSL_LISTEN =
     std::string_view{"/var/lib/nginx/lan_ssl.listen"};
 
-static constexpr auto LAN_SSL_LISTEN_DEFAULT =
+static constexpr auto LAN_SSL_LISTEN_DEFAULT = //TODO(pst) deprecate
     std::string_view{"/var/lib/nginx/lan_ssl.listen.default"};
 
 static constexpr auto ADD_SSL_FCT = std::string_view{"add_ssl"};
@@ -79,28 +77,30 @@ auto get_if_missed(const std::string & conf, const Line & LINE,
 
 
 auto delete_if(const std::string & conf, const rgx::regex & rgx,
-               const std::string & val="", bool compare=false)
+               const std::string & val="")
     -> std::string;
 
 
-void add_ssl_directives_to(const std::string & name, bool isdefault);
+void check_ssl_certificate(const std::string & crtpath,
+                           const std::string & keypath);
 
 
-void create_ssl_certificate(const std::string & crtpath,
-                            const std::string & keypath,
-                            int days=792);
-
-
-void use_cron_to_recreate_certificate(const std::string & name);
+void install_cron_job(const Line & CRON_LINE, const std::string & name="");
 
 
 void add_ssl_if_needed(const std::string & name);
 
 
-void del_ssl_directives_from(const std::string & name, bool isdefault);
+void remove_cron_job(const Line & CRON_LINE, const std::string & name="");
+
+
+auto del_ssl_legacy(const std::string & name) -> bool;
 
 
 void del_ssl(const std::string & name);
+
+
+void check_ssl(const uci::package & pkg);
 
 
 constexpr auto _begin = _Line{
@@ -191,6 +191,8 @@ constexpr auto _escape = _Line{
 };
 
 
+constexpr std::string_view _check_ssl = "check_ssl";
+
 constexpr std::string_view _server_name = "server_name";
 
 constexpr std::string_view _include = "include";
@@ -210,9 +212,12 @@ constexpr std::string_view _ssl_session_timeout = "ssl_session_timeout";
 //   https://p99.gforge.inria.fr/p99-html/group__preprocessor__for.html
 // * Use constexpr---not available for strings or char * for now---look at lib.
 
+static const auto CRON_CHECK = Line::build
+    <_space, _escape<NGINX_UTIL>, _space, _escape<_check_ssl,'\''>, _newline>();
+
 static const auto CRON_CMD = Line::build
-    < _space, _escape<NGINX_UTIL>, _space, _escape<ADD_SSL_FCT,'\''>, _space,
-        _capture<>, _newline >();
+    <_space, _escape<NGINX_UTIL>, _space, _escape<ADD_SSL_FCT,'\''>, _space,
+        _capture<>, _newline>();
 
 static const auto NGX_SERVER_NAME =
     Line::build<_begin, _escape<_server_name>, _space, _capture<';'>, _end>();
@@ -221,15 +226,15 @@ static const auto NGX_INCLUDE_LAN_LISTEN = Line::build
     <_begin, _escape<_include>, _space, _escape<LAN_LISTEN,'\''>, _end>();
 
 static const auto NGX_INCLUDE_LAN_LISTEN_DEFAULT = Line::build
-    < _begin, _escape<_include>, _space,
-        _escape<LAN_LISTEN_DEFAULT, '\''>, _end >();
+    <_begin, _escape<_include>, _space,
+        _escape<LAN_LISTEN_DEFAULT, '\''>, _end>();
 
 static const auto NGX_INCLUDE_LAN_SSL_LISTEN = Line::build
     <_begin, _escape<_include>, _space, _escape<LAN_SSL_LISTEN, '\''>, _end>();
 
 static const auto NGX_INCLUDE_LAN_SSL_LISTEN_DEFAULT = Line::build
-    < _begin, _escape<_include>, _space,
-        _escape<LAN_SSL_LISTEN_DEFAULT, '\''>, _end >();
+    <_begin, _escape<_include>, _space,
+        _escape<LAN_SSL_LISTEN_DEFAULT, '\''>, _end>();
 
 static const auto NGX_SSL_CRT = Line::build
     <_begin, _escape<_ssl_certificate>, _space, _capture<';'>, _end>();
@@ -242,6 +247,10 @@ static const auto NGX_SSL_SESSION_CACHE = Line::build
 
 static const auto NGX_SSL_SESSION_TIMEOUT = Line::build
     <_begin, _escape<_ssl_session_timeout>, _space, _capture<';'>, _end>();
+
+
+
+// ------------------------- implementation: ----------------------------------
 
 
 auto get_if_missed(const std::string & conf, const Line & LINE,
@@ -271,7 +280,7 @@ auto get_if_missed(const std::string & conf, const Line & LINE,
 
 
 auto delete_if(const std::string & conf, const rgx::regex & rgx,
-               const std::string & val, const bool compare)
+               const std::string & val)
     -> std::string
 {
     std::string ret{};
@@ -282,7 +291,8 @@ auto delete_if(const std::string & conf, const rgx::regex & rgx,
          pos += match.position(0) + match.length(0))
     {
         const std::string value = match.str(match.size() - 1);
-        auto len = match.position(1);
+        auto len = match.position( match.size()>1 ? 1 : 0 );
+        bool compare = !val.empty();
         if (compare && value!=val && value!="'"+val+"'" && value!='"'+val+'"') {
             len = match.position(0) + match.length(0);
         }
@@ -294,7 +304,7 @@ auto delete_if(const std::string & conf, const rgx::regex & rgx,
 }
 
 
-void add_ssl_directives_to(const std::string & name, const bool isdefault)
+inline void add_ssl_directives_to(const std::string & name, const bool isdefault)
 {
     const std::string prefix = std::string{CONF_DIR} + name;
 
@@ -306,7 +316,7 @@ void add_ssl_directives_to(const std::string & name, const bool isdefault)
         rgx::regex_search(pos, const_conf.end(), match, NGX_SERVER_NAME.RGX());
         pos += match.position(0) + match.length(0))
     {
-        if (match.str(2).find(name) == std::string::npos) { continue; }
+        if (match.str(2).find(name) == std::string::npos) { continue; } //else:
 
         const std::string indent = match.str(1);
 
@@ -392,19 +402,17 @@ inline auto get_nonce(const T salt=0) -> T
 }
 
 
-void create_ssl_certificate(const std::string & crtpath,
-                            const std::string & keypath,
-                            const int days)
+inline void create_ssl_certificate(const std::string & crtpath,
+                                   const std::string & keypath,
+                                   const int days=792)
 {
     size_t nonce = 0;
 
     try { nonce = get_nonce(nonce); }
 
     catch (...) { // the address of a variable should be random enough:
-        auto addr = &crtpath;
-        auto addrptr = static_cast<const size_t *>(
-                        static_cast<const void *>(&addr) );
-        nonce += *addrptr;
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) sic:
+        nonce += reinterpret_cast<size_t>(&crtpath);
     }
 
     auto noncestr = num2hex(nonce);
@@ -455,49 +463,14 @@ void create_ssl_certificate(const std::string & crtpath,
         perror(errmsg.c_str());
     }
 
+    std::cerr<<"Created self-signed SSL certificate '"<<crtpath;
+    std::cerr<<"' with key '"<<keypath<<"'.\n";
 }
 
 
-void use_cron_to_recreate_certificate(const std::string & name)
+inline void check_ssl_certificate(const std::string & crtpath,
+                                  const std::string & keypath)
 {
-    static const char * filename = "/etc/crontabs/root";
-
-    std::string conf{};
-    try { conf = read_file(filename); }
-    catch (const std::ifstream::failure &) { /* is ok if not found, create. */ }
-
-    const std::string add = get_if_missed(conf, CRON_CMD, name);
-
-    if (add.length() > 0) {
-#ifndef NO_UBUS
-        auto service = ubus::call("service","list",UBUS_TIMEOUT).filter("cron");
-
-        if (!service) {
-            std::string errmsg{"use_cron_to_recreate_certificate error: "};
-            errmsg += "Cron unavailable to re-create the ssl certificate for ";
-            errmsg += name + "\n";
-            throw std::runtime_error(errmsg.c_str());
-        } // else active with or without instances:
-#endif
-
-        write_file(filename, std::string{CRON_INTERVAL}+add, std::ios::app);
-
-#ifndef NO_UBUS
-        call("/etc/init.d/cron", "reload");
-#endif
-
-        std::cerr<<"Rebuild the ssl certificate for '";
-        std::cerr<<name<<"' annually with cron."<<std::endl;
-    }
-}
-
-
-void add_ssl_if_needed(const std::string & name)
-{
-    add_ssl_directives_to(name, name==LAN_NAME); // let it throw.
-
-    const auto crtpath = std::string{CONF_DIR} + name + ".crt";
-    const auto keypath = std::string{CONF_DIR} + name + ".key";
     constexpr auto remaining_seconds = (365 + 32)*24*60*60;
     constexpr auto validity_days = 3*(365 + 31);
 
@@ -526,16 +499,167 @@ void add_ssl_if_needed(const std::string & name)
     }
 
     if (!is_valid) { create_ssl_certificate(crtpath, keypath, validity_days); }
+}
 
-    try { use_cron_to_recreate_certificate(name); }
-    catch (...) {
-        std::cerr<<"add_ssl_if_needed warning: ";
-        std::cerr<<"cannot use cron to rebuild certificate for "<<name<<"\n";
+
+inline auto add_ssl_to_config(const std::string & name)
+{
+    auto sec = uci::package{"nginx"}[name]; // let it throw.
+
+    struct { std::string crt; std::string key; } ret;
+
+    auto cache = false;
+    auto timeout = false;
+    for (auto opt : sec) {
+
+        if (opt.name()=="ssl_session_cache") { cache = true; continue; } //else:
+
+        if (opt.name()=="ssl_session_timeout") { timeout=true; continue; }
+
+        //else:
+        for (auto itm : opt) {
+
+            if (opt.name()=="ssl_certificate_key") { ret.key = itm.name(); }
+
+            else if (opt.name()=="ssl_certificate") { ret.crt = itm.name(); }
+
+            else if (opt.name()=="listen" || opt.name()==LISTEN_LOCALLY) {
+                static const auto rgx_port =
+                    rgx::regex{R"(^\s*([^:]*:|\[[^]]*\]:)?80(\s|$|;))"};
+                auto val = regex_replace(itm.name(), rgx_port, "$01443 ssl$2");
+                itm.rename(val.c_str());
+            }
+        }
+    }
+
+    sec.set(MANAGE_SSL.data(), "true");
+
+    if (ret.crt.empty()) {
+        ret.crt = std::string{CONF_DIR} + name + ".crt";
+        sec.set("ssl_certificate", ret.crt.c_str());
+    }
+
+    if (ret.key.empty()) {
+        ret.key = std::string{CONF_DIR} + name + ".key";
+        sec.set("ssl_certificate_key", ret.key.c_str());
+    }
+
+    if (!cache)
+    { sec.set("ssl_session_cache", SSL_SESSION_CACHE_ARG(name).data()); }
+
+    if (!timeout)
+    { sec.set("ssl_session_timeout", SSL_SESSION_TIMEOUT_ARG.data()); }
+
+    sec.commit();
+
+    return ret;
+}
+
+
+void install_cron_job(const Line & CRON_LINE, const std::string & name)
+{
+    static const char * filename = "/etc/crontabs/root";
+
+    std::string conf{};
+    try { conf = read_file(filename); }
+    catch (const std::ifstream::failure &) { /* is ok if not found, create. */ }
+
+    const std::string add = get_if_missed(conf, CRON_LINE, name);
+
+    if (add.length() > 0) {
+#ifndef NO_UBUS
+        auto service = ubus::call("service","list",UBUS_TIMEOUT).filter("cron");
+
+        if (!service) {
+            std::string errmsg{"install_cron_job error: "};
+            errmsg += "Cron unavailable to re-create the ssl certificate";
+            errmsg += (name.empty() ? std::string{"s\n"} : " for '"+name+"'\n");
+            throw std::runtime_error(errmsg.c_str());
+        } //else active with or without instances:
+#endif
+
+        write_file(filename, std::string{CRON_INTERVAL}+add, std::ios::app);
+
+#ifndef NO_UBUS
+        call("/etc/init.d/cron", "reload");
+#endif
+
+        std::cerr<<"Rebuild the self-signed SSL certificate";
+        std::cerr<<(name.empty() ? std::string{"s"} : " for '"+name+"'");
+        std::cerr<<" annually with cron."<<std::endl;
     }
 }
 
 
-void del_ssl_directives_from(const std::string & name, const bool isdefault)
+void add_ssl_if_needed(const std::string & name)
+{
+    const auto legacypath = std::string{CONF_DIR} + name + ".conf";
+    if (access(legacypath.c_str(), R_OK)==0) {
+        add_ssl_directives_to(name, name==LAN_NAME); // let it throw.
+
+        const auto crtpath = std::string{CONF_DIR} + name + ".crt";
+        const auto keypath = std::string{CONF_DIR} + name + ".key";
+        check_ssl_certificate(crtpath, keypath); // let it throw.
+
+        try { install_cron_job(CRON_CMD, name); }
+        catch (...) {
+            std::cerr<<"add_ssl_if_needed warning: cannot use cron to rebuild ";
+            std::cerr<<"the self-signed SSL certificate for "<<name<<"\n";
+        }
+        return;
+    } //else:
+
+    auto paths = add_ssl_to_config(name); // let it throw.
+
+    check_ssl_certificate(paths.crt, paths.key); // let it throw.
+
+    try { install_cron_job(CRON_CHECK); }
+    catch (...) {
+        std::cerr<<"add_ssl_if_needed warning: cannot use cron to rebuild ";
+        std::cerr<<"the self-signed SSL certificates.\n";
+    }
+}
+
+
+void remove_cron_job(const Line & CRON_LINE, const std::string & name)
+{
+    static const char * filename = "/etc/crontabs/root";
+
+    const auto const_conf = read_file(filename);
+
+    bool changed = false;
+    auto conf = std::string{};
+
+    size_t prev = 0;
+    size_t curr = 0;
+    while ((curr=const_conf.find('\n', prev)) != std::string::npos) {
+
+        auto line = const_conf.substr(prev, curr-prev+1);
+
+        if (line==delete_if(line, CRON_LINE.RGX(), name)) {
+            conf += line;
+        } else { changed = true; }
+
+        prev = curr + 1;
+    }
+
+    if (changed) {
+        write_file(filename, conf);
+
+        std::cerr<<"Do not rebuild the self-signed SSL certificate";
+        std::cerr<<(name.empty() ? std::string{"s"} : " for '"+name+"'");
+        std::cerr<<" annually with cron anymore."<<std::endl;
+
+#ifndef NO_UBUS
+        if (ubus::call("service", "list", UBUS_TIMEOUT).filter("cron"))
+        { call("/etc/init.d/cron", "reload"); }
+#endif
+    }
+}
+
+
+inline void del_ssl_directives_from(const std::string & name,
+                                    const bool isdefault)
 {
     const std::string prefix = std::string{CONF_DIR} + name;
 
@@ -566,10 +690,10 @@ void del_ssl_directives_from(const std::string & name, const bool isdefault)
                 : delete_if(conf, NGX_INCLUDE_LAN_SSL_LISTEN.RGX());
 
             const auto crtpath = prefix+".crt";
-            conf = delete_if(conf, NGX_SSL_CRT.RGX(), crtpath, true);
+            conf = delete_if(conf, NGX_SSL_CRT.RGX(), crtpath);
 
             const auto keypath = prefix+".key";
-            conf = delete_if(conf, NGX_SSL_KEY.RGX(), keypath, true);
+            conf = delete_if(conf, NGX_SSL_KEY.RGX(), keypath);
 
             conf = delete_if(conf, NGX_SSL_SESSION_CACHE.RGX());
 
@@ -590,44 +714,69 @@ void del_ssl_directives_from(const std::string & name, const bool isdefault)
 }
 
 
-void del_ssl(const std::string & name)
+inline auto del_ssl_from_config(const std::string & name)
 {
-    static const char * filename = "/etc/crontabs/root";
+    auto sec = uci::package{"nginx"}[name]; // let it throw.
 
-    try {
-        const auto const_conf = read_file(filename);
+    struct { std::string crt; std::string key; } ret;
 
-        bool changed = false;
-        auto conf = std::string{};
+    auto manage = false;
+    for (auto opt : sec) {
 
-        size_t prev = 0;
-        size_t curr = 0;
-        while ((curr=const_conf.find('\n', prev)) != std::string::npos) {
+        if (opt.name()=="ssl_session_cache") { opt.del(); continue; } //else:
 
-            auto line = const_conf.substr(prev, curr-prev+1);
+        if (opt.name()=="ssl_session_timeout") { opt.del(); continue; } //else:
 
-            if (line==delete_if(line,CRON_CMD.RGX(),std::string{name},true)) {
-                conf += line;
-            } else { changed = true; }
+        for (auto itm : opt) {
 
-            prev = curr + 1;
+            if (opt.name()=="ssl_certificate") {
+                ret.crt = itm.name();
+                opt.del();
+                break;
+            } //else:
+
+            if (opt.name()=="ssl_certificate_key") {
+                ret.key = itm.name();
+                opt.del();
+                break;
+            } //else:
+
+            if (opt.name()==MANAGE_SSL && itm) {
+                manage = true;
+                opt.del();
+                break;
+            } //else:
+
+            if (opt.name()=="listen" || opt.name()==LISTEN_LOCALLY) {
+                static const auto rgx_port = rgx::regex
+                    {R"(^\s*([^:]*:|\[[^]]*\]:)?443(\s.*)?\sssl(\s|$|;))"};
+                auto val = regex_replace(itm.name(), rgx_port, "$0180$2$3");
+                itm.rename(val.c_str());
+                continue;
+            }
         }
+    }
+    if (manage) {
+        sec.commit();
+        return ret;
+    } //else:
 
-        if (changed) {
-            write_file(filename, conf);
+    auto errmsg = std::string{"del_ssl error: not changing the server config "};
+    errmsg += "without: uci set nginx."+name+"."+MANAGE_SSL.data()+"=true ";
+    throw std::runtime_error(errmsg);
+}
 
-            std::cerr<<"Do not rebuild the ssl certificate for '";
-            std::cerr<<name<<"' annually with cron anymore."<<std::endl;
 
-#ifndef NO_UBUS
-            if (ubus::call("service", "list", UBUS_TIMEOUT).filter("cron"))
-            { call("/etc/init.d/cron", "reload"); }
-#endif
-        }
+auto del_ssl_legacy(const std::string & name) -> bool
+{
+    const auto legacypath = std::string{CONF_DIR} + name + ".conf";
 
-    } catch (...) {
-        std::cerr<<"del_ssl warning: ";
-        std::cerr<<"cannot delete cron job for "<<name<<" in "<<filename<<"\n";
+    if (access(legacypath.c_str(), R_OK)!=0) { return false; }
+
+    try { remove_cron_job(CRON_CMD, name); }
+    catch (...) {
+        std::cerr<<"del_ssl warning: cannot remove cron job rebuilding ";
+        std::cerr<<"the self-signed SSL certificate for "<<name<<"\n";
     }
 
     try { del_ssl_directives_from(name, name==LAN_NAME); }
@@ -637,19 +786,83 @@ void del_ssl(const std::string & name)
         throw;
     }
 
-    const auto crtpath = std::string{CONF_DIR} + name + ".crt";
+    return true;
+}
+
+
+void del_ssl(const std::string & name)
+{
+    auto crtpath = std::string{};
+    auto keypath = std::string{};
+
+    if (del_ssl_legacy(name)) { //let it throw.
+        crtpath = std::string{CONF_DIR} + name + ".crt";
+        keypath = std::string{CONF_DIR} + name + ".key";
+    }
+
+    else {
+        auto paths = del_ssl_from_config(name); //let it throw.
+        crtpath = paths.crt;
+        keypath = paths.key;
+    }
 
     if (remove(crtpath.c_str())!=0) {
         auto errmsg = "del_ssl warning: cannot remove "+crtpath;
         perror(errmsg.c_str());
     }
 
-    const auto keypath = std::string{CONF_DIR} + name + ".key";
-
     if (remove(keypath.c_str())!=0) {
         auto errmsg = "del_ssl warning: cannot remove "+keypath;
         perror(errmsg.c_str());
     }
+}
+
+
+void check_ssl(const uci::package & pkg)
+{
+    auto at_least_one_has_manage_ssl = false;
+
+    for (auto sec : pkg) {
+        if (sec.anonymous() || sec.type()!="server") { continue; } //else:
+
+        const auto legacypath = std::string{CONF_DIR}+sec.name()+".conf";
+        if (access(legacypath.c_str(), R_OK)==0) { continue; } //else:
+
+        auto keypath = std::string{};
+        auto crtpath = std::string{};
+        auto manage = false;
+
+        for (auto opt : sec) {
+            for (auto itm : opt) {
+                if (opt.name()=="ssl_certificate_key") { keypath = itm.name(); }
+                else if (opt.name()=="ssl_certificate") { crtpath = itm.name();}
+                else if (opt.name()==MANAGE_SSL && itm) { manage = true; }
+            }
+        }
+
+        if (manage && !crtpath.empty() && !keypath.empty()) {
+            at_least_one_has_manage_ssl = true;
+
+            try { check_ssl_certificate(crtpath, keypath); }
+            catch (...) {
+                std::cerr<<"check_ssl warning: cannot build certificate '";
+                std::cerr<<crtpath<<"' or key '"<<keypath<<"'.\n";
+            }
+        }
+    }
+
+    auto suffix = std::string_view
+        {" cron job checking the self-signed SSL certificates.\n"};
+
+    if (at_least_one_has_manage_ssl) {
+        try { install_cron_job(CRON_CHECK); }
+        catch (...) { std::cerr<<"check_ssl warning: cannot install"<<suffix; }
+    }
+
+    else if(access("/etc/crontabs/root", R_OK) == 0) {
+        try { remove_cron_job(CRON_CHECK); }
+        catch (...) { std::cerr<<"check_ssl warning: cannot remove"<<suffix; }
+    } //else: do nothing
 }
 
 

--- a/net/nginx-util/src/px5g-openssl.hpp
+++ b/net/nginx-util/src/px5g-openssl.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <unistd.h>
 
+
 static constexpr auto rsa_min_modulus_bits = 512;
 
 using EVP_PKEY_ptr = std::unique_ptr<EVP_PKEY, decltype(&::EVP_PKEY_free)>;
@@ -52,11 +53,20 @@ inline auto print_error(const char * str, const size_t  /*len*/, void * errmsg)
 }
 
 
+// wrapper for clang-tidy:
+inline auto _BIO_new_fp(FILE * stream, const bool use_pem,
+                        const bool close=false) -> BIO *
+{
+    return BIO_new_fp( stream,  //NOLINTNEXTLINE(hicpp-signed-bitwise) macros:
+            (use_pem ? BIO_FP_TEXT : 0) | (close ? BIO_CLOSE : BIO_NOCLOSE) );
+}
+
+
 auto checkend(const std::string & crtpath,
               const time_t seconds, const bool use_pem) -> bool
 {
     BIO * bio = crtpath.empty() ?
-        BIO_new_fp(stdin, BIO_NOCLOSE | (use_pem ? BIO_FP_TEXT : 0)) :
+        _BIO_new_fp(stdin, use_pem) :
         BIO_new_file(crtpath.c_str(), (use_pem ? "r" : "rb"));
 
     X509 * x509 = nullptr;
@@ -71,7 +81,7 @@ auto checkend(const std::string & crtpath,
     if (x509==nullptr) {
         std::string errmsg{"checkend error: unable to load certificate\n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     time_t checktime = time(nullptr) + seconds;
@@ -91,7 +101,7 @@ auto gen_eckey(const int curve) -> EVP_PKEY_ptr
         std::string errmsg{"gen_eckey error: cannot build group for curve id "};
         errmsg += std::to_string(curve) + "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     EC_GROUP_set_asn1_flag(group, OPENSSL_EC_NAMED_CURVE);
@@ -115,18 +125,18 @@ auto gen_eckey(const int curve) -> EVP_PKEY_ptr
         std::string errmsg{"gen_eckey error: cannot build key with curve id "};
         errmsg += std::to_string(curve) + "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     EVP_PKEY_ptr pkey{EVP_PKEY_new(), ::EVP_PKEY_free};
 
-    auto tmp = static_cast<char *>(static_cast<void *>(eckey));
-
-    if (!EVP_PKEY_assign_EC_KEY(pkey.get(), tmp)) {
+    // EVP_PKEY_assign_EC_KEY is a macro casting eckey to char *:
+    //NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    if (!EVP_PKEY_assign_EC_KEY(pkey.get(), eckey)) {
         EC_KEY_free(eckey);
         std::string errmsg{"gen_eckey error: cannot assign EC key to EVP\n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     return pkey;
@@ -139,14 +149,14 @@ auto gen_rsakey(const int keysize, const BN_ULONG exponent) -> EVP_PKEY_ptr
         std::string errmsg{"gen_rsakey error: RSA keysize ("};
         errmsg += std::to_string(keysize) + ") out of range [512..";
         errmsg += std::to_string(OPENSSL_RSA_MAX_MODULUS_BITS) + "]";
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
     auto bignum = BN_new();
 
     if (bignum == nullptr) {
         std::string errmsg{"gen_rsakey error: cannot get big number struct\n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     auto rsa = RSA_new();
@@ -167,18 +177,18 @@ auto gen_rsakey(const int keysize, const BN_ULONG exponent) -> EVP_PKEY_ptr
         errmsg += std::to_string(keysize) + " and exponent ";
         errmsg += std::to_string(exponent) + "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     EVP_PKEY_ptr pkey{EVP_PKEY_new(), ::EVP_PKEY_free};
 
-    auto tmp = static_cast<char *>(static_cast<void *>(rsa));
-
-    if (!EVP_PKEY_assign_RSA(pkey.get(), tmp)) {
+    // EVP_PKEY_assign_RSA is a macro casting rsa to char *:
+    //NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    if (!EVP_PKEY_assign_RSA(pkey.get(), rsa)) {
         RSA_free(rsa);
         std::string errmsg{"gen_rsakey error: cannot assign RSA key to EVP\n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     return pkey;
@@ -190,20 +200,21 @@ void write_key(const EVP_PKEY_ptr & pkey,
 {
     BIO * bio = nullptr;
 
-    if (keypath.empty()) {
-        bio = BIO_new_fp( stdout, BIO_NOCLOSE | (use_pem ? BIO_FP_TEXT : 0) );
+    if (keypath.empty()) { bio = _BIO_new_fp(stdout, use_pem); }
 
-    } else { // BIO_new_file(keypath.c_str(), (use_pem ? "w" : "wb") );
+    else { // BIO_new_file(keypath.c_str(), (use_pem ? "w" : "wb") );
 
         static constexpr auto mask = 0600;
         // auto fd = open(keypath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, mask);
+        // creat has no cloexec, alt. triggers cppcoreguidelines-pro-type-vararg
+        //NOLINTNEXTLINE(android-cloexec-creat)
         auto fd = creat(keypath.c_str(), mask); // the same without va_args.
 
         if (fd >= 0) {
             auto fp = fdopen(fd, (use_pem ? "w" : "wb") );
 
             if (fp != nullptr) {
-                bio = BIO_new_fp(fp, BIO_CLOSE | (use_pem ? BIO_FP_TEXT : 0));
+                bio = _BIO_new_fp(fp, use_pem, true);
                 if (bio == nullptr) { fclose(fp); } // (fp owns fd)
             }
             else { close(fd); }
@@ -216,7 +227,7 @@ void write_key(const EVP_PKEY_ptr & pkey,
         errmsg += keypath.empty() ? "stdout" : keypath;
         errmsg += "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     int len = 0;
@@ -249,7 +260,7 @@ void write_key(const EVP_PKEY_ptr & pkey,
         errmsg += keypath.empty() ? "stdout" : keypath;
         errmsg += "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 }
 
@@ -265,7 +276,7 @@ auto subject2name(const std::string & subject) -> X509_NAME_ptr
     if (!name) {
         std::string errmsg{"subject2name error: cannot create X509 name \n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     if (subject.empty()) { return name; }
@@ -287,19 +298,21 @@ auto subject2name(const std::string & subject) -> X509_NAME_ptr
             if (nid == NID_undef) {
                 // skip unknown entries (silently?).
             } else {
-                auto val = static_cast<const unsigned char *>(
-                                static_cast<const void *>(&subject[prev]) );
+                auto val = // X509_NAME_add_entry_by_NID wants it unsigned:
+                    //NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                    reinterpret_cast<const unsigned char *>(&subject[prev]);
 
                 auto len = i - prev;
 
-                if ( X509_NAME_add_entry_by_NID(name.get(), nid, MBSTRING_ASC,
-                                                  val, len, -1, 0)
+                if ( X509_NAME_add_entry_by_NID(name.get(), nid,
+                        MBSTRING_ASC, //NOLINT(hicpp-signed-bitwise) is macro
+                        val, len, -1, 0)
                     == 0 )
                 {
                     std::string errmsg{"subject2name error: cannot add "};
                     errmsg += "/" + type +"="+ subject.substr(prev, len) +"\n";
                     ERR_print_errors_cb(print_error, &errmsg);
-                    throw std::runtime_error(errmsg.c_str());
+                    throw std::runtime_error(errmsg);
                 }
             }
             chr = '=';
@@ -320,7 +333,7 @@ void selfsigned(const EVP_PKEY_ptr & pkey, const int days,
     if (x509 == nullptr) {
         std::string errmsg{"selfsigned error: cannot create X509 structure\n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     auto freeX509_and_throw = [&x509](const std::string & what)
@@ -329,7 +342,7 @@ void selfsigned(const EVP_PKEY_ptr & pkey, const int days,
         std::string errmsg{"selfsigned error: cannot set "};
         errmsg += what + " in X509 certificate\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     };
 
     if (X509_set_version(x509, 2) == 0) { freeX509_and_throw("version"); }
@@ -380,7 +393,7 @@ void selfsigned(const EVP_PKEY_ptr & pkey, const int days,
     }
 
     BIO * bio = crtpath.empty() ?
-        BIO_new_fp(stdout, BIO_NOCLOSE | (use_pem ? BIO_FP_TEXT : 0)) :
+        _BIO_new_fp(stdout, use_pem) :
         BIO_new_file(crtpath.c_str(), (use_pem ? "w" : "wb"));
 
     int len = 0;
@@ -399,7 +412,7 @@ void selfsigned(const EVP_PKEY_ptr & pkey, const int days,
         errmsg += crtpath.empty() ? "stdout" : crtpath;
         errmsg += "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 }
 

--- a/net/nginx-util/src/px5g.cpp
+++ b/net/nginx-util/src/px5g.cpp
@@ -174,7 +174,7 @@ void eckey(const argv_view & argv)
             if (has_main_option) {
                 throw std::runtime_error
                     ("eckey error: more than one main option");
-            } // else:
+            } //else:
             has_main_option = true;
 
             curve = parse_curve(argv[i]);
@@ -223,7 +223,7 @@ void rsakey(const argv_view & argv)
 
             if (has_main_option) {
                 throw std::runtime_error("rsakey error: more than one keysize");
-            } // else:
+            } //else:
             has_main_option = true;
 
             try {

--- a/net/nginx-util/src/ubus-cxx.cpp
+++ b/net/nginx-util/src/ubus-cxx.cpp
@@ -1,0 +1,148 @@
+#include <iostream>
+
+#include "ubus-cxx.hpp"
+
+
+inline void example_for_checking_if_there_is_a_key()
+{
+    if (ubus::call("service", "list").filter("cron")) {
+        std::cout<<"Cron is active (with or without instances) "<<std::endl;
+    }
+}
+
+
+inline void example_for_getting_values()
+{
+    auto lan_status = ubus::call("network.interface.lan", "status");
+    for (auto t : lan_status.filter("ipv6-address", "", "address")) {
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        auto x = const_cast<blob_attr *>(t);
+        std::cout<<"["<<blobmsg_get_string(x)<<"] ";
+    }
+    for (auto t : lan_status.filter("ipv4-address", "").filter("address")) {
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        auto x = const_cast<blob_attr *>(t);
+        std::cout<<blobmsg_get_string(x)<<" ";
+    }
+    std::cout<<std::endl;
+}
+
+
+inline void example_for_sending_message()
+{
+    auto set_arg = [](blob_buf * buf) -> int
+        { return blobmsg_add_string(buf, "config", "nginx"); };
+    for (auto t : ubus::call("uci", "get", set_arg).filter("values")) {
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        auto x = const_cast<blob_attr *>(t);
+        std::cout<<blobmsg_get_string(x)<<"\n";
+    }
+}
+
+
+inline void example_for_exploring()
+{
+    ubus::strings keys{"ipv4-address", "", ""};
+    for (auto t : ubus::call("network.interface.lan", "status").filter(keys)) {
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        auto x = const_cast<blob_attr *>(t);
+        std::cout<<blobmsg_name(x)<<": ";
+        switch (blob_id(x)) {
+            case BLOBMSG_TYPE_UNSPEC: std::cout<<"[unspecified]"; break;
+            case BLOBMSG_TYPE_ARRAY: std::cout<<"[array]"; break;
+            case BLOBMSG_TYPE_TABLE: std::cout<<"[table]"; break;
+            case BLOBMSG_TYPE_STRING: std::cout<<blobmsg_get_string(x); break;
+            case BLOBMSG_TYPE_INT64: std::cout<<blobmsg_get_u64(x); break;
+            case BLOBMSG_TYPE_INT32: std::cout<<blobmsg_get_u32(x); break;
+            case BLOBMSG_TYPE_INT16: std::cout<<blobmsg_get_u16(x); break;
+            case BLOBMSG_TYPE_BOOL: std::cout<<blobmsg_get_bool(x); break;
+            case BLOBMSG_TYPE_DOUBLE: std::cout<<blobmsg_get_double(x); break;
+            default: std::cout<<"[unknown]";
+        }
+        std::cout<<std::endl;
+    }
+}
+
+
+inline void example_for_recursive_exploring()
+{ // output like from the original ubus call:
+    const auto explore = [](auto message) -> void
+    {
+        auto end = message.end();
+        auto explore_internal =
+            [&end](auto & explore_ref, auto it, size_t depth=1) -> void
+        {
+            std::cout<<std::endl;
+            bool first = true;
+            for (; it!=end; ++it) {
+                //NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                auto attr = const_cast<blob_attr *>(*it);
+                if (first) { first = false; }
+                else { std::cout<<",\n"; }
+                std::cout<<std::string(depth, '\t');
+                std::string name = blobmsg_name(attr);
+                if (!name.empty()) {  std::cout<<"\""<<name<<"\": "; }
+                switch (blob_id(attr)) {
+                    case BLOBMSG_TYPE_UNSPEC: std::cout<<"(unspecified)"; break;
+                    case BLOBMSG_TYPE_ARRAY:
+                        std::cout<<"[";
+                        explore_ref(explore_ref, ubus::iterator{attr}, depth+1);
+                        std::cout<<"\n"<<std::string(depth, '\t')<<"]";
+                        break;
+                    case BLOBMSG_TYPE_TABLE:
+                        std::cout<<"{";
+                        explore_ref(explore_ref, ubus::iterator{attr}, depth+1);
+                        std::cout<<"\n"<<std::string(depth, '\t')<<"}";
+                        break;
+                    case BLOBMSG_TYPE_STRING:
+                        std::cout<<"\""<<blobmsg_get_string(attr)<<"\"";
+                        break;
+                    case BLOBMSG_TYPE_INT64:
+                        std::cout<<blobmsg_get_u64(attr);
+                        break;
+                    case BLOBMSG_TYPE_INT32:
+                        std::cout<<blobmsg_get_u32(attr);
+                        break;
+                    case BLOBMSG_TYPE_INT16:
+                        std::cout<<blobmsg_get_u16(attr);
+                        break;
+                    case BLOBMSG_TYPE_BOOL:
+                        std::cout<<(blobmsg_get_bool(attr) ? "true" : "false");
+                        break;
+                    case BLOBMSG_TYPE_DOUBLE:
+                        std::cout<<blobmsg_get_double(attr);
+                        break;
+                    default: std::cout<<"(unknown)"; break;
+                }
+            }
+        };
+        std::cout<<"{";
+        explore_internal(explore_internal, message.begin());
+        std::cout<<"\n}"<<std::endl;
+    };
+    explore(ubus::call("network.interface.lan", "status"));
+}
+
+
+auto main() -> int {
+
+    try {
+        example_for_checking_if_there_is_a_key();
+
+        example_for_getting_values();
+
+        example_for_sending_message();
+
+        example_for_exploring();
+
+        example_for_recursive_exploring();
+
+        return 0;
+    }
+
+    catch (const std::exception & e) { std::cerr<<e.what()<<std::endl; }
+
+    catch (...) { perror("main error"); }
+
+    return 1;
+}

--- a/net/nginx-util/src/uci-cxx.cpp
+++ b/net/nginx-util/src/uci-cxx.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "uci-cxx.hpp"
+
+
+auto main() -> int {
+
+    uci::element p = uci::package{"nginx"};
+    std::cout<<"package "<<p.name()<<"\n\n";
+    for (auto s : p) {
+        std::cout<<"config "<<s.type()<<" '"<<s.name()<<"'\n";
+        for (auto o : s) {
+            for (auto i : o) {
+                std::cout<<"\t"<<o.type()<<" "<<o.name()<<" '"<<i.name()<<"'\n";
+            }
+        }
+        std::cout<<"\n";
+    }
+
+}

--- a/net/nginx-util/src/uci-cxx.hpp
+++ b/net/nginx-util/src/uci-cxx.hpp
@@ -1,0 +1,510 @@
+#ifndef _UCI_CXX_HPP
+#define _UCI_CXX_HPP
+
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <uci.h>
+
+
+namespace uci {
+
+
+
+template<class T>
+class iterator { // like uci_foreach_element_safe.
+
+private:
+
+    const uci_ptr & _ptr;
+
+    uci_element * _it = nullptr;
+
+    uci_element * _next = nullptr;
+
+    // wrapper for clang-tidy
+    inline auto _list_to_element(const uci_list * cur) -> uci_element * {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        return list_to_element(cur); // macro casting container=pointer-offset.
+    }
+
+
+public:
+
+    inline explicit iterator(const uci_ptr & ptr, const uci_list * cur)
+    : _ptr{ptr}, _it{_list_to_element(cur)}
+    { _next = _list_to_element(_it->list.next); }
+
+
+    inline iterator(iterator &&) noexcept = default;
+
+
+    inline iterator(const iterator &) = delete;
+
+
+    inline auto operator=(const iterator &) -> iterator & = delete;
+
+
+    inline auto operator=(iterator &&) -> iterator & = delete;
+
+
+    auto operator*() -> T { return T{_ptr, _it}; }
+
+
+    inline auto operator!=(const iterator & rhs) -> bool
+    { return (&_it->list != &rhs._it->list); }
+
+
+    inline auto operator++() -> iterator &
+    {
+        _it = _next;
+        _next = _list_to_element(_next->list.next);
+        return *this;
+    }
+
+
+    inline ~iterator() = default;
+
+};
+
+
+
+class locked_context {
+
+private:
+
+    static std::mutex inuse;
+
+
+public:
+
+    inline locked_context() { inuse.lock(); }
+
+    inline locked_context(locked_context &&) noexcept = default;
+
+    inline locked_context(const locked_context &) = delete;
+
+    inline auto operator=(const locked_context &) -> locked_context & = delete;
+
+    inline auto operator=(locked_context &&) -> locked_context & = delete;
+
+
+    //NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    inline auto get() -> uci_context * // is member to enforce inuse
+    {
+        static auto free_ctx = [](uci_context * ctx) { uci_free_context(ctx); };
+        static std::unique_ptr<uci_context, decltype(free_ctx)>
+            lazy_ctx{uci_alloc_context(), free_ctx};
+
+        if (!lazy_ctx) { // it could be available on a later call:
+            lazy_ctx.reset(uci_alloc_context());
+            if (!lazy_ctx) {
+                throw std::runtime_error("uci error: cannot allocate context");
+            }
+        }
+
+        return lazy_ctx.get();
+    }
+
+
+    inline ~locked_context() { inuse.unlock(); }
+
+};
+
+
+
+template<class T>
+class element {
+
+private:
+
+    uci_list * _begin = nullptr;
+
+    uci_list * _end = nullptr;
+
+    uci_ptr _ptr{};
+
+
+protected:
+
+    [[nodiscard]] inline auto ptr() -> uci_ptr & { return _ptr; }
+
+
+    [[nodiscard]] inline auto ptr() const -> const uci_ptr & { return _ptr; }
+
+
+    void init_begin_end(uci_list * begin, uci_list * end)
+    {
+        _begin = begin;
+        _end = end;
+    }
+
+
+    inline explicit element(const uci_ptr & pre, uci_element * last)
+    : _ptr{pre} { _ptr.last = last; }
+
+
+    inline explicit element() = default;
+
+
+public:
+
+    inline element(element &&) noexcept = default;
+
+
+    inline element(const element &) = delete;
+
+
+    inline auto operator=(const element &) -> element & = delete;
+
+
+    inline auto operator=(element &&) -> element & = delete;
+
+
+    auto operator[](std::string_view key) const -> T;
+
+
+    [[nodiscard]] inline auto name() const -> std::string
+    { return _ptr.last->name; }
+
+
+    void rename(const char * value) const;
+
+
+    void commit() const;
+
+
+    [[nodiscard]] inline auto begin() const -> iterator<T>
+    { return iterator<T>{_ptr, _begin}; }
+
+
+    [[nodiscard]] inline auto end() const -> iterator<T>
+    { return iterator<T>{_ptr, _end}; }
+
+
+    inline ~element() = default;
+
+};
+
+
+class section;
+
+class option;
+
+class item;
+
+
+
+class package : public element<section> {
+
+public:
+
+    inline package(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        ptr().p = uci_to_package(ptr().last); // macro casting pointer-offset.
+        ptr().package = ptr().last->name;
+
+        auto end = &ptr().p->sections;
+        auto begin = end->next;
+        init_begin_end(begin, end);
+    }
+
+
+    explicit package(const char * name);
+
+
+    auto set(const char * key, const char * type) const -> section;
+
+};
+
+
+
+class section : public element<option> {
+
+public:
+
+    inline section(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        ptr().s = uci_to_section(ptr().last); // macro casting pointer-offset.
+        ptr().section = ptr().last->name;
+
+        auto end = &ptr().s->options;
+        auto begin = end->next;
+        init_begin_end(begin, end);
+    }
+
+
+    auto set(const char * key, const char * value) const -> option;
+
+
+    void del();
+
+
+    [[nodiscard]] inline auto anonymous() const -> bool
+    { return ptr().s->anonymous; }
+
+
+    [[nodiscard]] inline auto type() const -> std::string
+    { return ptr().s->type; }
+
+};
+
+
+
+class option : public element<item> {
+
+public:
+
+    inline option(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        ptr().o = uci_to_option(ptr().last); // macro casting pointer-offset.
+        ptr().option = ptr().last->name;
+
+        if (ptr().o->type==UCI_TYPE_LIST) { // use union ptr().o->v as list:
+            //NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+            auto end = &ptr().o->v.list;
+            auto begin = end->next;
+            init_begin_end(begin, end);
+        } else {
+            auto begin = &ptr().last->list;
+            auto end = begin->next;
+            init_begin_end(begin, end);
+        }
+    }
+
+
+    void del();
+
+
+    [[nodiscard]] inline auto type() const -> std::string
+    { return (ptr().o->type==UCI_TYPE_LIST ? "list" : "option"); }
+
+};
+
+
+
+class item : public element<item> {
+
+public:
+
+    inline item(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    { ptr().value = ptr().last->name; }
+
+
+    [[nodiscard]] inline auto type() const -> std::string
+    { return (ptr().o->type==UCI_TYPE_LIST ? "list" : "option"); }
+
+
+    [[nodiscard]] inline auto name() const -> std::string
+    {
+        return ( ptr().last->type==UCI_TYPE_ITEM ? ptr().last->name :
+                 //else: use union ptr().o->v as string:
+                 //NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+                 ptr().o->v.string );
+    }
+
+
+    inline explicit operator bool() const
+    {
+        const auto x = std::string_view{name()};
+
+        if (x=="0" || x=="off" || x=="false" || x=="no" || x=="disabled")
+        { return false; }
+
+        if (x=="1" || x=="on" || x=="true" || x=="yes" || x=="enabled")
+        { return true; }
+
+        auto errmsg = std::string{"uci_error: item is not bool "} + name();
+        throw std::runtime_error(errmsg.c_str());
+    }
+
+
+    void rename(const char * value) const;
+
+};
+
+
+
+// ------------------------- implementation: ----------------------------------
+
+
+std::mutex locked_context::inuse{};
+
+
+inline auto uci_error(uci_context * ctx, const char * prefix=nullptr)
+    -> std::runtime_error
+{
+    char * errmsg = nullptr;
+    uci_get_errorstr(ctx, &errmsg, prefix);
+
+    std::unique_ptr<char, decltype(&std::free)> auto_free{errmsg, std::free};
+    return std::runtime_error{errmsg};
+}
+
+
+template<class T>
+auto element<T>::operator[](std::string_view key) const -> T
+{
+    for (auto elmt : *this) { if (elmt.name()==key) { return elmt; } }
+
+    auto errmsg = std::string{"uci error: cannot find "}.append(key);
+    throw uci_error(locked_context{}.get(), errmsg.c_str());
+}
+
+
+template<class T>
+void element<T>::rename(const char * value) const
+{
+    if (value==name()) { return; }
+
+    auto ctx = locked_context{};
+    auto tmp_ptr = uci_ptr{_ptr};
+    tmp_ptr.value = value;
+    if (uci_rename(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot rename "}.append(name());
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+template<class T>
+void element<T>::commit() const
+{
+    auto ctx = locked_context{};
+    // TODO(pst) use when possible:
+    // if (uci_commit(ctx.get(), &_ptr.p, true) != 0) {
+    //    auto errmsg = std::string{"uci error: cannot commit "} + _ptr.package;
+    //    throw uci_error(ctx.get(), errmsg.c_str());
+    // }
+    auto err = uci_save(ctx.get(), _ptr.p);
+    if (err==0) {
+        uci_context * tmp_ctx = uci_alloc_context();
+        err = tmp_ctx==nullptr;
+        uci_package * tmp_pkg = nullptr;
+        if (err==0) { err = uci_load(tmp_ctx, _ptr.package, &tmp_pkg); }
+        if (err==0) { err = uci_commit(tmp_ctx, &tmp_pkg, false); }
+        if (err==0) { err = uci_unload(tmp_ctx, tmp_pkg); }
+        if (tmp_ctx!=nullptr) { uci_free_context(tmp_ctx); }
+    }
+
+    if (err != 0) {
+        auto errmsg = std::string{"uci error: cannot commit "} + _ptr.package;
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+package::package(const char * name)
+{
+    auto ctx = locked_context{};
+
+    auto pkg = uci_lookup_package(ctx.get(), name);
+    if (pkg==nullptr) {
+        if (uci_load(ctx.get(), name, &pkg) != 0) {
+            auto errmsg = std::string{"uci error: cannot load package "} + name;
+            throw uci_error(ctx.get(), errmsg.c_str());
+        }
+    }
+
+    ptr().package = name;
+    ptr().p = pkg;
+    ptr().last = &pkg->e;
+
+    auto end = &ptr().p->sections;
+    auto begin = end->next;
+    init_begin_end(begin, end);
+}
+
+
+auto package::set(const char * key, const char * type) const -> section
+{
+    auto ctx = locked_context{};
+
+    auto tmp_ptr = uci_ptr{ptr()};
+    tmp_ptr.section = key;
+    tmp_ptr.value = type;
+    if (uci_set(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot set section "} + type
+            + "'" + key + "' in package " + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+
+    return section{ptr(), tmp_ptr.last};
+}
+
+
+auto section::set(const char * key, const char * value) const -> option
+{
+    auto ctx = locked_context{};
+
+    auto tmp_ptr = uci_ptr{ptr()};
+    tmp_ptr.option = key;
+    tmp_ptr.value = value;
+    if (uci_set(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot set option "} + key
+            + "'" + value + "' in package " + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+
+    return option{ptr(), tmp_ptr.last};
+}
+
+
+void section::del()
+{
+    auto ctx = locked_context{};
+    if (uci_delete(ctx.get(), &ptr()) != 0) {
+        auto errmsg = std::string{"uci error: cannot delete section "} + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+void option::del()
+{
+    auto ctx = locked_context{};
+    if (uci_delete(ctx.get(), &ptr()) != 0) {
+        auto errmsg = std::string{"uci error: cannot delete option "} + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+void item::rename(const char * value) const
+{
+    if (value==name()) { return; }
+
+    auto ctx = locked_context{};
+    auto tmp_ptr = uci_ptr{ptr()};
+
+    if (tmp_ptr.last->type!=UCI_TYPE_ITEM) {
+        tmp_ptr.value = value;
+        if (uci_set(ctx.get(), &tmp_ptr) != 0) {
+            auto errmsg = std::string{"uci error: cannot rename item "}+name();
+            throw uci_error(ctx.get(), errmsg.c_str());
+        }
+        return;
+    } //else:
+
+    tmp_ptr.value = tmp_ptr.last->name;
+    if (uci_del_list(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot rename (del) "} + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+
+    tmp_ptr.value = value;
+    if (uci_add_list(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot rename (add) "} + value;
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+} // namespace uci
+
+#endif


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, x86_64 qemu, master
Run tested: (put here arch, model, OpenWrt version, tests done) TODO

Description:
Parse the UCI configuration for package `nginx`. Create a server part
in `/var/lib/nginx/$name.conf` for every `section server '$name'` by
copying all UCI options but the following:

* `option manage_selfsigned '[bool]'` is skipped. It is set to true
by `nginx-util add_ssl $name`, removed by `nginx-util del_ssl $name` and
used by `nginx-util check_ssl` (see below).

* `list listen_locally '$port ...'`: Is replaced by a set of directives
of the form `listen $ip:$port ...;` using all local IPs. It can occur
more than one time with different ports.

* `logd` as path in `error_log` or `access_log` forwards the log to
STDERR respective STDOUT, which is fowarded by Nginx's init to the log
daemon. Specifically:
`option error_log 'logd'` -> `error_log stderr;`
`option access_log 'logd openwrt'`->`access_log /proc/self/fd/1 openwrt;`

Other `[option|list] key 'value'` entries become `key value;` directives.

The package includes also the UCI configuration file `/etc/config/nginx`
with a default server listening on all local IPs (and one redirecting
inexistent URLs to https in the SSL versions). Furthermore, it installs
also the file `/etc/nginx/conf.d/_uci.conf` for including the
`/var/lib/nginx/*.conf` server parts that are created by Nginx's init
with `nginx-util init_lan`.

If there is a file named `/etc/nginx/conf.d/$name.conf` the functions
`init_lan`, `add_ssl $name` and `del_ssl $name` will use that file
instead of a UCI server section with the same $name.

Else if there is only a UCI `section server $name`:
* `nginx-util add_ssl $name` will add to it:
`option manage_selfsigned 'true'`
`option ssl_certificate '/etc/nginx/conf.d/$name.crt'`
`option ssl_certificate_key '/etc/nginx/conf.d/$name.key'`
`option ssl_session_cache 'shared:SSL:32k'`
`option ssl_session_timeout '64m'`
If these options are already present, they will stay the same; just the
first option `manage_selfsigned` will always be changed to 'true'.
The command also changes all `listen` and `listen_locally` list items to
use port 443 and ssl instead of port 80. If the stated another port than
80 before, they are kept the same. Furthermore, it creates a self-signed
SSL certificate if necessary, i.e., if there is no *valid* certificate
and key at the locations given by the options `ssl_certificate` and
`ssl_certificate_key`.

* `nginx-util del_ssl $name` checks if `manage_selfsigned` is set 'true'
in the corresponding UCI section. Only then it removes all of the above
options regardless of the value looking just at the key name. Then, it
also changes all `listen` and `listen_locally` list items to use port 80
(without ssl) instead of port 443 with ssl. Furthermore, it removes the
SSL certificate and key that were indicated by `ssl_certificate{,_key}`.

* `nginx-util check_ssl` looks through all server sections of the UCI
config for `manage_selfsigned 'true'`. On every hit it checks if the SSL
certificate-key-pair indicated by the options `ssl_certificate{,_key}` is
expired. Then it re-creates a self-signed certificate.
If there exists a `section server` with `manage_selfsigned 'true'`, it
will try to install itself as cron job. If there are no such sections,
it remove that cron job if possible.

The default server installed by Nginx in `/etc/nginx/conf.d/_lan.conf`
and `/etc/nginx/conf.d/_redirect2ssl.conf` can be removed. Then the UCI
config will come into effect.