### PR TITLE
nginx-util: use uci for server configuraton

### DIFF
--- a/net/nginx-util/Makefile
+++ b/net/nginx-util/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx-util
-PKG_VERSION:=1.3
-PKG_RELEASE:=2
+PKG_VERSION:=1.4
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
 
 include $(INCLUDE_DIR)/package.mk
@@ -11,18 +11,21 @@ include $(INCLUDE_DIR)/cmake.mk
 CMAKE_OPTIONS+= -DUBUS=y
 CMAKE_OPTIONS+= -DVERSION=$(PKG_VERSION)
 
+
 define Package/nginx-util/default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=Nginx configurator
-  DEPENDS:=+libstdcpp +libubus +libubox +libpthread
+  DEPENDS:=+libstdcpp +libuci +libubus +libubox +libpthread
 endef
+
 
 define Package/nginx-util
   $(Package/nginx-util/default)
   CONFLICTS:=nginx-ssl-util-nopcre nginx-ssl-util
 endef
+
 
 define Package/nginx-ssl-util/default
   $(Package/nginx-util/default)
@@ -31,6 +34,7 @@ define Package/nginx-ssl-util/default
   CONFLICTS:=,nginx-util
 endef
 
+
 define Package/nginx-ssl-util
   $(Package/nginx-ssl-util/default)
   TITLE+= (using PCRE)
@@ -38,43 +42,97 @@ define Package/nginx-ssl-util
   CONFLICTS+= ,nginx-ssl-util-nopcre
 endef
 
+
 define Package/nginx-ssl-util-nopcre
   $(Package/nginx-ssl-util/default)
   TITLE+= (using <regex>)
   CONFLICTS+= nginx-ssl-util
 endef
 
+
 define Package/nginx-util/description
   Utility that builds dynamically LAN listen directives for Nginx.
 endef
+
 
 Package/nginx-ssl-util/default/description = $(Package/nginx-util/description)\
   Furthermore, it manages SSL directives for its server parts and can create \
   corresponding (self-signed) certificates.
 
+
 Package/nginx-ssl-util/description = \
   $(Package/nginx-ssl-util/default/description) \
   It uses the PCRE library for performance.
+
 
 Package/nginx-ssl-util-nopcre/description = \
   $(Package/nginx-ssl-util/default/description) \
   It uses the standard regex library of C++.
 
+
+define Package/nginx-util/install/default
+	$(INSTALL_DIR) $(1)/etc/nginx/conf.d/
+	$(INSTALL_CONF) ./files/uci.conf.template $(1)/etc/nginx/
+	$(LN) /var/lib/nginx/uci.conf $(1)/etc/nginx/uci.conf
+endef
+
+
 define Package/nginx-util/install
+	$(call Package/nginx-util/install/default, $(1))
+
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) ./files/config-nginx $(1)/etc/config/nginx
+
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nginx-util $(1)/usr/bin/nginx-util
 endef
 
+
+define Package/nginx-ssl-util/install/default
+	$(call Package/nginx-util/install/default, $(1))
+
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) ./files/config-nginx-ssl $(1)/etc/config/nginx
+
+ifneq ($(CONFIG_IPV6),y)
+	$(SED) "/listen\s*'\[/d" $(1)/etc/config/nginx # without IPv6 [::]
+endif
+endef
+
+
 define Package/nginx-ssl-util/install
+	$(call Package/nginx-ssl-util/install/default, $(1))
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nginx-ssl-util $(1)/usr/bin/nginx-util
 endef
 
+
 define Package/nginx-ssl-util-nopcre/install
+	$(call Package/nginx-ssl-util/install/default, $(1))
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nginx-ssl-util-nopcre \
 		$(1)/usr/bin/nginx-util
 endef
+
+
+define Package/nginx-ssl-util/prerm
+#!/bin/sh
+
+[ -z "$${IPKG_INSTROOT}" ] && exit 0
+[ "$${PKG_UPGRADE}" = "1" ] && exit 0
+
+eval "$$(/usr/bin/nginx-util get_env)"
+
+[ "$$(/sbin/uci get "nginx.$${LAN_NAME}.$${MANAGE_SSL}" 2>/dev/null)" = \
+	"self-signed" ] &&
+rm -f "$${CONF_DIR}$${LAN_NAME}.crt" "$${CONF_DIR}$${LAN_NAME}.key"
+
+exit 0
+endef
+
+
+Package/nginx-ssl-util-nopcre/prerm = $(Package/nginx-ssl-util/prerm)
+
 
 $(eval $(call BuildPackage,nginx-util))
 $(eval $(call BuildPackage,nginx-ssl-util))

--- a/net/nginx-util/files/README.sh
+++ b/net/nginx-util/files/README.sh
@@ -1,0 +1,514 @@
+#!/bin/sh
+# This is a template copy it by: ./README.sh | xclip -selection c
+# to https://openwrt.org/docs/guide-user/services/webserver/nginx#configuration
+
+NGINX_UTIL="/usr/bin/nginx-util"
+
+EXAMPLE_COM="example.com"
+
+MSG="
+/* Created by the following bash script that includes the source of some files:
+ * https://github.com/openwrt/packages/net/nginx-util/files/README.sh
+ */"
+
+eval $("${NGINX_UTIL}" get_env)
+
+code() {
+    local file
+    [ $# -gt 1 ] && file="$2" || file="$(basename "$1")"
+    printf "<file nginx %s>\n%s</file>" "$1" "$(cat "${file}")";
+}
+
+ifConfEcho() {
+    sed -nE "s/^\s*$1=\s*(\S*)\s*\\\\$/\n$2 \"\1\";/p" ../../nginx/Makefile;
+}
+
+cat <<EOF
+
+
+
+
+
+===== Configuration =====${MSG}
+
+
+
+The official Documentation contains a
+[[https://docs.nginx.com/nginx/admin-guide/|Admin Guide]].
+Here we will look at some often used configuration parts and how we handle them
+at OpenWrt.
+At different places there are references to the official
+[[https://docs.nginx.com/nginx/technical-specs/|Technical Specs]]
+for further reading.
+
+**tl;dr:** When starting Nginx by ''/etc/init.d/nginx'', it creates its main
+configuration dynamically based on a minimal template and the
+[[docs:guide-user:base-system:uci|🡒UCI]] configuration.
+
+The UCI ''/etc/config/nginx'' contains initially:
+| ''config server '${LAN_NAME}''' | \
+Default server for th LAN, which includes all ''${CONF_DIR}*.locations''. |
+| ''config server '_redirect2ssl''' | \
+Redirects inexistent URLs to HTTPS (installed only for Nginx with SSL). |
+
+It enables also the ''${CONF_DIR}'' directory for further configuration:
+| ''${CONF_DIR}\$NAME.conf'' | \
+Is included in the main configuration. \
+It is prioritized over a UCI ''config server '\$NAME' ''. |
+| ''${LAN_LISTEN}'' | \
+For including in HTTP servers to make them reachable from LAN. |
+| ''${LAN_SSL_LISTEN}'' | \
+For including in HTTPS servers to make them available on LAN. |
+
+Setup configuration (for a server ''\$NAME''):
+| ''$(basename ${NGINX_UTIL}) [${ADD_SSL_FCT}|del_ssl] \$NAME''  | \
+Add/remove a self-signed certificate and corresponding directives. |
+| ''uci add_list nginx.\$NAME.${LISTEN_LOCALLY}=…'' | \
+Makes the server reachable from LAN. |
+| ''uci set nginx.\$NAME.access_log='logd openwrt''' | \
+Writes accesses to Openwrt’s \
+[[docs:guide-user:base-system:log.essentials|🡒logd]]. |
+| ''uci set nginx.\$NAME.error_log='logd' '' | \
+Writes errors to Openwrt’s \
+[[docs:guide-user:base-system:log.essentials|🡒logd]]. |
+| ''uci [set|add_list] nginx.\$NAME.key='value' '' | \
+Becomes a ''key value;'' directive if the //key// does not start with //uci_//. |
+| ''uci set nginx.\$NAME=[disable|server]'' |\
+Disable/enable inclusion in the dynamic conf.|
+| ''uci set nginx.global.uci_enable=false'' | \
+Use a custom ''${NGINX_CONF}'' rather than a dynamic conf. |
+
+
+
+==== Basic ====${MSG}
+
+
+We modify the configuration by changing servers saved in the UCI configuration
+at ''/etc/config/nginx'' and/or by creating different configuration files in the
+''${CONF_DIR}'' directory.
+These files use the file extensions ''.locations'' and ''.conf'' (plus ''.crt''
+and ''.key'' for Nginx with SSL).((
+We can disable a single configuration file by giving it another extension, e.g.,
+by adding ''.disabled''.))
+For the new configuration to take effect, we must reload it by:
+
+<code bash>service nginx reload</code>
+
+For OpenWrt we use a special initial configuration, which is explained in the
+section [[#openwrt_s_defaults|🡓OpenWrt’s Defaults]].
+So, we can make a site available at a specific URL in the **LAN** by creating a
+''.locations'' file in the directory ''${CONF_DIR}''.
+Such a file consists just of some
+[[https://nginx.org/en/docs/http/ngx_http_core_module.html#location|
+location blocks]].
+Under the latter link, you can find also the official documentation for all
+available directives of the HTTP core of Nginx.
+Look for //location// in the Context list.
+
+The following example provides a simple template, see at the end for
+different [[#locations_for_apps|🡓Locations for Apps]]((look for
+[[https://github.com/search?utf8=%E2%9C%93&q=repo%3Aopenwrt%2Fpackages
++extension%3Alocations&type=Code&ref=advsearch&l=&l=|
+other packages using a .locations file]], too.)):
+
+<code nginx $(basename ${CONF_DIR})/example.locations>
+location /ex/am/ple {
+	access_log off; # default: not logging accesses.
+	# access_log /proc/self/fd/1 openwrt; # use logd (init forwards stdout).
+	# error_log stderr; # default: logging to logd (init forwards stderr).
+	error_log /dev/null; # disable error logging after config file is read.
+	# (state path of a file for access_log/error_log to the file instead.)
+	index index.html;
+}
+# location /eg/static { … }
+</code>
+
+All location blocks in all ''.locations'' files must use different URLs,
+since they are all included in the ''${LAN_NAME}'' server that is part of the
+[[#openwrt_s_defaults|🡓OpenWrt’s Defaults]].((
+We reserve the ''location /'' for making LuCI available under the root URL,
+e.g. [[http://192.168.1.1/|192.168.1.1/]].
+All other sites shouldn’t use the root ''location /'' without suffix.))
+We should make other sites than LuCI available on the root URL of **other**
+domain names only, e.g. on //www.example.com///.
+In order to do that, we create [[#new_server_parts|🡓New Server Parts]] for all
+domain names.
+For Nginx with SSL we can also activate SSL thereby, see
+[[#ssl_server_parts|🡓SSL Server Parts]].
+We use such server parts also for publishing sites to the internet (WAN)
+instead of making them available just locally (in the LAN).
+
+Via ''${CONF_DIR}*.conf'' files we can add directives to the //http// part of
+the configuration.
+If you would change the configuration ''$(basename "${UCI_CONF}").template''
+instead, it is not updated to new package's versions anymore.
+Although it is not recommended, you can also disable the whole UCI config and
+create your own ''${NGINX_CONF}''; then invoke:
+
+<code bash>uci set nginx.global.uci_enable=false</code>
+
+
+
+==== New Server Parts ====${MSG}
+
+
+For making the router reachable from the WAN at a registered domain name,
+it is not enough to give the name server the internet IP address of the router
+(maybe updated automatically by a
+[[docs:guide-user:services:ddns:client|🡒DDNS Client]]).
+We also need to set up virtual hosting for this domain name by creating an
+appropriate server section in ''/etc/config/nginx''
+or in a ''${CONF_DIR}*.conf'' file, but which cannot be changed by UCI).
+All such parts are included in the main configuration of OpenWrt
+([[#openwrt_s_defaults|🡓OpenWrt’s Defaults]]).
+
+In the server part, we state the domain as
+[[https://nginx.org/en/docs/http/ngx_http_core_module.html#server_name|
+server_name]].
+The link points to the same document as for the location blocks in the
+[[#basic|🡑Basic Configuration]]: the official documentation for all available
+directives of the HTTP core of Nginx.
+This time look for //server// in the Context list, too.
+The server part should also contain similar location blocks as
+++before.|
+We can re-include a ''.locations'' file that is included in the server part for
+the LAN by default.
+Then the site is reachable under the same path at both domains, e.g., by
+http://192.168.1.1/ex/am/ple as well as by http://example.com/ex/am/ple.
+++
+
+The [[#openwrt_s_defaults|🡓OpenWrt’s Defaults]] has a
+''config server '${LAN_NAME}' '' containing a server part that listens on the
+LAN address(es) and acts as //default_server//.
+For making another domain name accessible in the LAN, too, the corresponding
+server part must listen **explicitly** on the local IP address(es), cf. the
+official documentation on
+[[https://nginx.org/en/docs/http/request_processing.html|request_processing]].
+We can do so by adding to the UCI config ''list ${LISTEN_LOCALLY} '\$PORT …' ''.
+When starting Nginx, each of them is
+++substituted| by
+''listen \$IP:\$PORT …;'' directives with ''\$IP'' running through all LAN
+addresses.
+Hereby, we can replace ''…'' by any argument that is recognized by Nginx’s
+[[https://nginx.org/en/docs/http/ngx_http_core_module.html#listen|listen]]
+directive (NB: there can only be one //default_server// for each port)
+++.
+
+We can add more directives by invoking
+''uci [set|add_list] nginx.${EXAMPLE_COM//./_}.key=value''.
+If the //key// is not starting with //uci_//, it becomes a ''key value;''
+++directive.|
+Although the UCI config does not support nesting like Nginx, we can add a whole
+block as //value//.
+++
+
+We cannot use dots in a //key// name other than in the //value//.
+In the following example we replace the dot in //${EXAMPLE_COM}// by an
+underscore for the UCI name of the server, but not for Nginx's //server_name//:
+
+<code bash>
+uci add nginx server &&
+uci rename nginx.@server[-1]=${EXAMPLE_COM//./_} &&
+uci add_list nginx.${EXAMPLE_COM//./_}.listen='80' &&
+uci add_list nginx.${EXAMPLE_COM//./_}.listen='[::]:80' &&
+uci add_list nginx.${EXAMPLE_COM//./_}.${LISTEN_LOCALLY}='80' &&
+uci set nginx.${EXAMPLE_COM//./_}.server_name='${EXAMPLE_COM}' &&
+uci add_list nginx.${EXAMPLE_COM//./_}.include=\
+'$(basename ${CONF_DIR})/${EXAMPLE_COM}.listen'
+# uci add_list nginx.${EXAMPLE_COM//./_}.location='/ { … }' \
+# root location for this server.
+</code>
+
+We can disable respective re-enable this server again:
+
+<code bash>
+uci set nginx.${EXAMPLE_COM//./_}=disable # respective: \
+uci set nginx.${EXAMPLE_COM//./_}=server
+</code>
+
+These changes are made in the RAM (and can be used until a reboot), we can save
+them permanently by:
+
+<code bash>uci commit nginx</code>
+
+For creating a similar ''${CONF_DIR}${EXAMPLE_COM}.conf'', we can include the
+file ''${LAN_LISTEN}'' that contains the listen directives for all LAN addresses
+on the HTTP port 80 and is updated automatically:
+/*, see
+ * [[https://github.com/search?q=repo%3Aopenwrt%2Fpackages
+ * +include+${LAN_LISTEN}+extension%3Aconf&type=Code|
+ * such server parts of other packages]], too:
+ */
+
+<code nginx $(basename ${CONF_DIR})/${EXAMPLE_COM}.conf>
+server {
+	listen 80;
+	listen [::]:80;
+	include '${LAN_LISTEN}';
+	server_name ${EXAMPLE_COM};
+	include '$(basename ${CONF_DIR})/${EXAMPLE_COM}.locations';
+	# location / { … } # root location for this server.
+}
+</code>
+
+Hereby, we cannot change the arguments of the LAN listen directives—unlike when
+using //${LISTEN_LOCALLY}// in the UCI config.
+
+
+
+==== SSL Server Parts ====${MSG}
+
+
+We can enable HTTPS for a domain if Nginx is installed with SSL support.
+We need a SSL certificate as well as its key and add them by the directives
+//ssl_certificate// respective //ssl_certificate_key// to the server part of the
+domain.
+The rest of the configuration is similar as for general
+[[#new_server_parts|🡑New Server Parts]],
+we only have to adjust the listen directives by adding the //ssl// parameter,
+see the official documentation for
+[[https://nginx.org/en/docs/http/configuring_https_servers.html|
+configuring HTTPS servers]], too.
+
+The official documentation of the SSL module contains an
+[[https://nginx.org/en/docs/http/ngx_http_ssl_module.html#example|
+example]], which includes some optimizations.
+We can extend an existing UCI server section similarly, e.g., for the above
+''config server '${EXAMPLE_COM//./_}' '' we invoke:
+
+<code bash>
+# Instead of 'del_list' the listen* entries, we could use '443 ssl' beforehand.
+uci del_list nginx.${EXAMPLE_COM//./_}.listen='80' &&
+uci del_list nginx.${EXAMPLE_COM//./_}.listen='[::]:80' &&
+uci del_list nginx.${EXAMPLE_COM//./_}.${LISTEN_LOCALLY}='80' &&
+uci add_list nginx.${EXAMPLE_COM//./_}.listen='443 ssl' &&
+uci add_list nginx.${EXAMPLE_COM//./_}.listen='[::]:443 ssl' &&
+uci add_list nginx.${EXAMPLE_COM//./_}.${LISTEN_LOCALLY}='443 ssl' &&
+uci set nginx.${EXAMPLE_COM//./_}.ssl_certificate=\
+'${CONF_DIR}${EXAMPLE_COM}.crt' &&
+uci set nginx.${EXAMPLE_COM//./_}.ssl_certificate_key=\
+'${CONF_DIR}${EXAMPLE_COM}.key' &&
+uci set nginx.${EXAMPLE_COM//./_}.ssl_session_cache=\
+'${SSL_SESSION_CACHE_ARG}' &&
+uci set nginx.${EXAMPLE_COM//./_}.ssl_session_timeout=\
+'${SSL_SESSION_TIMEOUT_ARG}' &&
+uci commit nginx
+</code>
+
+If we want to make the server in ''${CONF_DIR}${EXAMPLE_COM}.conf''
+available in the LAN via SSL, we can—additionally to adding the //ssl_*//
+directives—include the file ''${LAN_SSL_LISTEN}'' (instead of
+''$(basename "${LAN_LISTEN}")'').
+This file contains the listen directives with the //ssl// parameter for
+all LAN addresses on the HTTPS port 443 and is updated automatically.
+/*, see also
+ * [[https://github.com/search?q=repo%3Aopenwrt%2Fpackages
+ * +include+${LAN_SSL_LISTEN}+extension%3Aconf&type=Code|
+ * other packages providing SSL server parts]].
+ */
+
+The following command creates a **self-signed** SSL certificate and changes the
+corresponding configuration:
+
+<code bash>$(basename "${NGINX_UTIL}") ${ADD_SSL_FCT} ${EXAMPLE_COM//./_}</code>
+
+  - If a ''$(basename "${CONF_DIR}")/${EXAMPLE_COM//./_}.conf'' file exists, it\
+    adds //ssl_*// directives and changes the listen directives for the server.\
+    Else it does that for the UCI server like in the example above.
+  - Then, it checks if there is a certificate with key for the given name\
+    that is valid for at least 13 months or tries to create a self-signed one.
+  - When cron is activated, it installs a cron job for renewing the self-signed\
+    certificate every year if needed, too. We can activate cron by: \
+    <code bash>service cron enable && service cron start</code>
+
+This can be undone by invoking:
+
+<code bash>$(basename "${NGINX_UTIL}") del_ssl ${EXAMPLE_COM//./_}</code>
+
+For creating a certificate and its key signed by Let’s Encrypt we can use
+[[https://github.com/ndilieto/uacme|uacme]] or
+[[https://github.com/Neilpang/acme.sh|acme.sh]], which are installed by:
+
+<code bash>
+opkg update && opkg install uacme #or: acme #and for LuCI: luci-app-acme
+</code>
+
+[[#openwrt_s_defaults|🡓OpenWrt’s Defaults]] include a UCI server for the LAN:
+''config server '${LAN_NAME}' ''. It has //ssl_*// directives prepared for a
+self-signed SSL certificate((Let’s Encrypt (and other CAs) cannot sign
+certificates of a **local** server.))
+that is created on the first start of Nginx.
+Furthermore, there is also a UCI server named ''_redirect2ssl'' that redirects
+all HTTP requests for inexistent URLs to HTTPS.
+
+
+
+==== OpenWrt’s Defaults ====${MSG}
+
+
+Since Nginx is compiled with these presets, we can pretend that the main
+configuration will always contain the following directives
+(though we can overwrite them):
+
+<code nginx>$(ifConfEcho --pid-path pid)\
+$(ifConfEcho --lock-path lock_file)\
+$(ifConfEcho --error-log-path error_log)\
+$(false && ifConfEcho --http-log-path access_log)\
+$(ifConfEcho --http-proxy-temp-path proxy_temp_path)\
+$(ifConfEcho --http-client-body-temp-path client_body_temp_path)\
+$(ifConfEcho --http-fastcgi-temp-path fastcgi_temp_path)\
+</code>
+
+When starting or reloading the Nginx service, the ''/etc/init.d/nginx'' script
+sets also the following directives
+(so we cannot change them in the used configuration file):
+
+<code nginx>
+daemon off; # procd expects services to run in the foreground
+worker_processes '\$NCPUS'; # NCPUS="\$(grep -c '^processor\s*:' /proc/cpuinfo)"
+</code>
+
+Then, it creates the main configuration ''$(basename "${UCI_CONF}")''
+dynamically from the template:
+
+$(code "${UCI_CONF}.template")
+
+So, the access log is turned off by default and we can look at the error log
+by ''logread'', as Nginx’s init script forwards stderr and stdout to the
+[[docs:guide-user:base-system:log.essentials|🡒runtime log]].
+We can set the //error_log// and //access_log// to files, where the log
+messages are forwarded to instead (after the configuration is read).
+And for redirecting the access log of a //server// or //location// to the logd,
+too, we insert the following directive in the corresponding block:
+
+<code nginx>	access_log /proc/self/fd/1 openwrt;</code>
+
+If we setup a server through UCI, we can use the options //error_log// and/or
+//access_log// with the path
+++'logd'.|
+When initializing the Nginx service, this special path is replaced by //stderr//
+respective ///proc/self/fd/1// (which are forwarded to the runtime log).
+++
+
+For creating the configuration from the template shown above, the init.d script
+replaces the comment ''#UCI_HTTP_CONFIG'' by all UCI servers.
+For each server section in the the UCI configuration, it basically copies all
+options into a Nginx //server { … }// part, in detail:
+  * It replaces every ''list ${LISTEN_LOCALLY} '\$PORT …' '' by directives of\
+  the form ''listen \$IP:\$PORT …;'', where ''\$IP'' runs through all LAN\
+  addresses.
+  * Other options starting with ''uci_'' are skipped. Currently there is only\
+  the ''option ${MANAGE_SSL}=…'' in ++usage.| It is set to\
+  //'self-signed'// when invoking ''$(basename ${NGINX_UTIL}) $ADD_SSL_FCT …''.\
+  Then the corresponding certificate is re-newed if it is about to expire.\
+  All those certificates are checked on the initialization of the Nginx service\
+  and if Cron is available, it is deployed for checking them annually, too.++
+  * All other lists or options of the form ''key='value' '' are written\
+  one-to-one as ''key value;'' directives to the configuration file.\
+  Just the path //logd// has a special meaning for the logging directives\
+  (described in the previous paragraph).
+
+The init.d script of Nginx uses the //$(basename ${NGINX_UTIL})// for creating
+the configuration file
+++in RAM.|
+The main configuration ''${UCI_CONF}'' is a symbolic link to this place
+(it is a dead link if the Nginx service is not running).
+++
+
+We could use a custom configuration created at ''${NGINX_CONF}'' instead of the
+dynamic configuration, too.((
+For using a custom configuration at ''${NGINX_CONF}'', we execute
+<code bash>uci set nginx.global.uci_enable='false' </code>
+Then the rest of the UCI config is ignored and init.d will not create the main
+configuration dynamically from the template anymore.
+For Nginx with SSL invoking
+''$(basename ${NGINX_UTIL}) [add_ssl|del_ssl] \$FQDN''
+will still try to change a server in ''$(basename "${CONF_DIR}")/\$FQDN.conf''
+(this is less reliable than for a UCI config as it uses regular expressions, not
+a complete parser for the Nginx configuration).))
+This is not encouraged since you cannot setup servers using UCI anymore.
+Rather, we can put custom configuration parts to ''.conf'' files in the
+''${CONF_DIR}'' directory.
+The main configuration pulls in all ''$(basename "${CONF_DIR}")/*.conf'' files
+into the //http {…}// block behind the created UCI servers.
+
+The initial UCI config is enabled and contains a server section for the LAN:
+
+$(code "/etc/config/nginx" "config-nginx")
+
+The LAN server pulls in all ''.locations'' files from the directory
+''${CONF_DIR}''.
+We can install the location parts of different sites there (see
+[[#basic|🡑Basic Configuration]]) and re-include them into other servers.
+This is needed especially for making them available to the WAN
+([[#new_server_parts|🡑New Server Parts]]).
+The LAN server becomes the //default_server// for all local addresses on port 80
+via ''uci_listen_locally''.
+It creates one of the following directives for every IP address of the LAN:
+<code nginx>
+	listen IPv4:80 default_server;
+	listen [IPv6]:80 default_server;
+</code>
+
+If we want to make other servers also available on the LAN on port 80 through
+their //server_name//, we can add a ''uci_listen_locally '80' '' to them by,
+e.g.:
+
+<code bash>uci add_list nginx.${EXAMPLE_COM//./_}.${LISTEN_LOCALLY}='80'</code>
+
+This is possible for servers of the UCI config only.
+For server parts in ''$(basename "${CONF_DIR}")/*.conf'' we can include
+''${LAN_LISTEN}'' instead.
+This file contains //listen// directives for all local IPs with fixed port 80
+(and without //default_server//).
+
+As the configuration depends on the local IPs, it is (re-)created when the LAN
+interface changes.
+Then it is validated and the Nginx service is reloaded.
+We can do this also manually by:
+
+<code bash> service nginx reload </code>
+
+
+=== Additional Defaults for OpenWrt if Nginx is installed with SSL support ===
+
+When Nginx is installed with SSL support, it will also create an automatically
+managed ''$(basename "${LAN_SSL_LISTEN}")'' file in the directory
+''$(dirname "${LAN_SSL_LISTEN}")/'' containing //listen// directives with fixed
+port 443 and //ssl// parameter for all local IP addresses.
+
+We can include this file into a //server {…}// part in a ''${CONF_DIR}*.conf''
+file, for making the server available on the LAN via HTTPS.
+For UCI servers we can use (similar as for HTTP):
+
+<code nginx> list ${LISTEN_LOCALLY} '443 ssl' </code>
+
+This is needed as the initial UCI config for SSL contains a //default_server//
+for the LAN listening explicitly on local addresses, too.
+There is also a server section that redirects requests for an inexistent
+''server_name'' from HTTP to HTTPS. It acts as //default_server// if there is
+++no other|; it uses an invalid name for that, more in the official
+documentation on
+[[https://nginx.org/en/docs/http/request_processing.html|request_processing]]
+++:
+
+$(code "/etc/config/nginx" "config-nginx-ssl")
+
+When starting or reloading the Nginx service, the init.d looks which UCI servers
+have set ''option ${MANAGE_SSL} 'self-signed' '', e.g., the LAN server.
+For all those servers it checks if there is a certificate that is still valid
+for 13 months or (re-)creates a self-signed one.
+If there is any such server, it installs also a cron job that checks the
+corresponding certificates once a year.
+The option ''${MANAGE_SSL}'' is set to //'self-signed'// respectively removed
+from a UCI server named ''${EXAMPLE_COM//./_}'' by the following
+(see [[#ssl_server_parts|🡑SSL Server Parts]], too):
+
+<code bash>
+$(basename ${NGINX_UTIL}) ${ADD_SSL_FCT} ${EXAMPLE_COM//./_} \
+# respectively: \
+$(basename ${NGINX_UTIL}) del_ssl ${EXAMPLE_COM//./_}
+</code>
+
+
+EOF

--- a/net/nginx-util/files/config-nginx
+++ b/net/nginx-util/files/config-nginx
@@ -1,0 +1,9 @@
+
+config main global
+	option uci_enable 'true'
+
+config server '_lan'
+	list uci_listen_locally '80 default_server'
+	option server_name '_lan'
+	list include 'conf.d/*.locations'
+	option access_log 'off; # logd openwrt'

--- a/net/nginx-util/files/config-nginx-ssl
+++ b/net/nginx-util/files/config-nginx-ssl
@@ -1,0 +1,20 @@
+
+config main global
+	option uci_enable 'true'
+
+config server '_lan'
+	list uci_listen_locally '443 ssl default_server'
+	option server_name '_lan'
+	list include 'conf.d/*.locations'
+	option uci_manage_ssl 'self-signed'
+	option ssl_certificate '/etc/nginx/conf.d/_lan.crt'
+	option ssl_certificate_key '/etc/nginx/conf.d/_lan.key'
+	option ssl_session_cache 'shared:SSL:32k'
+	option ssl_session_timeout '64m'
+	option access_log 'off; # logd openwrt'
+
+config server '_redirect2ssl'
+	list listen '80'
+	list listen '[::]:80'
+	option server_name '_redirect2ssl'
+	option return '302 https://$host$request_uri'

--- a/net/nginx-util/files/uci.conf.template
+++ b/net/nginx-util/files/uci.conf.template
@@ -1,0 +1,30 @@
+# Consider using UCI or creating files in /etc/nginx/conf.d/ for configuration.
+# Parsing UCI configuration is skipped if uci set nginx.global.uci_enable=false
+# For details see: https://openwrt.org/docs/guide-user/services/webserver/nginx
+
+user root;
+
+events {}
+
+http {
+	access_log off;
+	log_format openwrt
+		'$request_method $scheme://$host$request_uri => $status'
+		' (${body_bytes_sent}B in ${request_time}s) <- $http_referer';
+
+	include mime.types;
+	default_type application/octet-stream;
+	sendfile on;
+
+	client_max_body_size 128M;
+	large_client_header_buffers 2 1k;
+
+	gzip on;
+	gzip_vary on;
+	gzip_proxied any;
+
+	root /www;
+
+	#UCI_HTTP_CONFIG
+	include conf.d/*.conf;
+}

--- a/net/nginx-util/src/CMakeLists.txt
+++ b/net/nginx-util/src/CMakeLists.txt
@@ -7,13 +7,20 @@ INCLUDE(CheckFunctionExists)
 
 IF(UBUS)
 FIND_PATH(ubus_include_dir libubus.h)
-FIND_LIBRARY(ubox NAMES ubox)
 FIND_LIBRARY(ubus NAMES ubus)
 INCLUDE_DIRECTORIES(${ubus_include_dir})
 ENDIF()
 
+FIND_PATH(ubox_include_dir libubox/blobmsg.h)
+FIND_LIBRARY(ubox NAMES ubox)
+INCLUDE_DIRECTORIES(${ubox_include_dir})
+
+FIND_PATH(uci_include_dir uci.h)
+FIND_LIBRARY(uci NAMES uci)
+INCLUDE_DIRECTORIES(${uci_include_dir})
+
 ADD_DEFINITIONS(-Os -Wall -Werror -Wextra -g3)
-ADD_DEFINITIONS(-Wno-unused-parameter -Wmissing-declarations)
+ADD_DEFINITIONS(-Wno-unused-parameter -Wmissing-declarations -Wshadow)
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 
@@ -24,23 +31,27 @@ ADD_COMPILE_DEFINITIONS(VERSION=${VERSION})
 
 ADD_EXECUTABLE(nginx-util nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-util PUBLIC -DNO_SSL)
-TARGET_LINK_LIBRARIES(nginx-util ${ubox} ${ubus} pthread)
+TARGET_LINK_LIBRARIES(nginx-util ${uci} ${ubox} ${ubus} pthread)
 INSTALL(TARGETS nginx-util RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util nginx-util.cpp)
-TARGET_LINK_LIBRARIES(nginx-ssl-util ${ubox} ${ubus} pthread ssl crypto pcre)
+TARGET_LINK_LIBRARIES(nginx-ssl-util ${uci} ${ubox} ${ubus} pthread ssl crypto pcre)
 INSTALL(TARGETS nginx-ssl-util RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util-nopcre nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-ssl-util-nopcre PUBLIC -DNO_PCRE)
-TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre ${ubox} ${ubus} pthread ssl crypto)
+TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre ${uci} ${ubox} ${ubus} pthread ssl crypto)
 INSTALL(TARGETS nginx-ssl-util-nopcre RUNTIME DESTINATION bin)
 
 ELSE()
 
+ADD_COMPILE_DEFINITIONS(VERSION=0)
+
 CONFIGURE_FILE(test-px5g.sh test-px5g.sh COPYONLY)
 CONFIGURE_FILE(test-nginx-util.sh test-nginx-util.sh COPYONLY)
 CONFIGURE_FILE(test-nginx-util-root.sh test-nginx-util-root.sh COPYONLY)
+CONFIGURE_FILE(../files/config-nginx-ssl config-nginx-ssl COPYONLY)
+CONFIGURE_FILE(../files/uci.conf.template uci.conf.template COPYONLY)
 
 ADD_EXECUTABLE(px5g px5g.cpp)
 TARGET_LINK_LIBRARIES(px5g ssl crypto)
@@ -48,12 +59,12 @@ INSTALL(TARGETS px5g RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util-noubus nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-ssl-util-noubus PUBLIC -DNO_UBUS)
-TARGET_LINK_LIBRARIES(nginx-ssl-util-noubus pthread ssl crypto pcre)
+TARGET_LINK_LIBRARIES(nginx-ssl-util-noubus ${uci} ${ubox} pthread ssl crypto pcre)
 INSTALL(TARGETS nginx-ssl-util-noubus RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util-nopcre-noubus nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-ssl-util-nopcre-noubus PUBLIC -DNO_PCRE -DNO_UBUS)
-TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre-noubus pthread ssl crypto)
+TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre-noubus ${uci} ${ubox} pthread ssl crypto)
 INSTALL(TARGETS nginx-ssl-util-nopcre-noubus RUNTIME DESTINATION bin)
 
 ENDIF()

--- a/net/nginx-util/src/nginx-ssl-util.hpp
+++ b/net/nginx-util/src/nginx-ssl-util.hpp
@@ -1,8 +1,6 @@
 #ifndef __NGINX_SSL_UTIL_HPP
 #define __NGINX_SSL_UTIL_HPP
 
-#include <thread>
-
 #ifdef NO_PCRE
 #include <regex>
 namespace rgx = std;
@@ -24,7 +22,7 @@ static constexpr auto CRON_INTERVAL = std::string_view{"3 3 12 12 *"};
 static constexpr auto LAN_SSL_LISTEN =
     std::string_view{"/var/lib/nginx/lan_ssl.listen"};
 
-static constexpr auto LAN_SSL_LISTEN_DEFAULT =
+static constexpr auto LAN_SSL_LISTEN_DEFAULT = //TODO(pst) deprecate
     std::string_view{"/var/lib/nginx/lan_ssl.listen.default"};
 
 static constexpr auto ADD_SSL_FCT = std::string_view{"add_ssl"};
@@ -79,28 +77,44 @@ auto get_if_missed(const std::string & conf, const Line & LINE,
 
 
 auto delete_if(const std::string & conf, const rgx::regex & rgx,
-               const std::string & val="", bool compare=false)
+               const std::string & val="")
     -> std::string;
 
 
-void add_ssl_directives_to(const std::string & name, bool isdefault);
+auto check_ssl_certificate(const std::string & crtpath,
+                           const std::string & keypath) -> bool;
 
 
-void create_ssl_certificate(const std::string & crtpath,
-                            const std::string & keypath,
-                            int days=792);
-
-
-void use_cron_to_recreate_certificate(const std::string & name);
+void install_cron_job(const Line & CRON_LINE, const std::string & name="");
 
 
 void add_ssl_if_needed(const std::string & name);
 
 
-void del_ssl_directives_from(const std::string & name, bool isdefault);
+void remove_cron_job(const Line & CRON_LINE, const std::string & name="");
+
+
+auto del_ssl_legacy(const std::string & name) -> bool;
 
 
 void del_ssl(const std::string & name);
+
+
+auto check_ssl(const uci::package & pkg, bool is_enabled) -> bool;
+
+
+inline void check_ssl(const uci::package & pkg)
+{
+    if (!check_ssl(pkg, is_enabled(pkg))) {
+#ifndef NO_UBUS
+        if (ubus::call("service", "list", UBUS_TIMEOUT).filter("nginx"))
+        {
+            call("/etc/init.d/nginx", "reload");
+            std::cerr<<"Reload Nginx.\n";
+        }
+#endif
+    }
+}
 
 
 constexpr auto _begin = _Line{
@@ -191,6 +205,8 @@ constexpr auto _escape = _Line{
 };
 
 
+constexpr std::string_view _check_ssl = "check_ssl";
+
 constexpr std::string_view _server_name = "server_name";
 
 constexpr std::string_view _include = "include";
@@ -210,9 +226,12 @@ constexpr std::string_view _ssl_session_timeout = "ssl_session_timeout";
 //   https://p99.gforge.inria.fr/p99-html/group__preprocessor__for.html
 // * Use constexpr---not available for strings or char * for now---look at lib.
 
+static const auto CRON_CHECK = Line::build
+    <_space, _escape<NGINX_UTIL>, _space, _escape<_check_ssl,'\''>, _newline>();
+
 static const auto CRON_CMD = Line::build
-    < _space, _escape<NGINX_UTIL>, _space, _escape<ADD_SSL_FCT,'\''>, _space,
-        _capture<>, _newline >();
+    <_space, _escape<NGINX_UTIL>, _space, _escape<ADD_SSL_FCT,'\''>, _space,
+        _capture<>, _newline>();
 
 static const auto NGX_SERVER_NAME =
     Line::build<_begin, _escape<_server_name>, _space, _capture<';'>, _end>();
@@ -221,15 +240,15 @@ static const auto NGX_INCLUDE_LAN_LISTEN = Line::build
     <_begin, _escape<_include>, _space, _escape<LAN_LISTEN,'\''>, _end>();
 
 static const auto NGX_INCLUDE_LAN_LISTEN_DEFAULT = Line::build
-    < _begin, _escape<_include>, _space,
-        _escape<LAN_LISTEN_DEFAULT, '\''>, _end >();
+    <_begin, _escape<_include>, _space,
+        _escape<LAN_LISTEN_DEFAULT, '\''>, _end>();
 
 static const auto NGX_INCLUDE_LAN_SSL_LISTEN = Line::build
     <_begin, _escape<_include>, _space, _escape<LAN_SSL_LISTEN, '\''>, _end>();
 
 static const auto NGX_INCLUDE_LAN_SSL_LISTEN_DEFAULT = Line::build
-    < _begin, _escape<_include>, _space,
-        _escape<LAN_SSL_LISTEN_DEFAULT, '\''>, _end >();
+    <_begin, _escape<_include>, _space,
+        _escape<LAN_SSL_LISTEN_DEFAULT, '\''>, _end>();
 
 static const auto NGX_SSL_CRT = Line::build
     <_begin, _escape<_ssl_certificate>, _space, _capture<';'>, _end>();
@@ -242,6 +261,10 @@ static const auto NGX_SSL_SESSION_CACHE = Line::build
 
 static const auto NGX_SSL_SESSION_TIMEOUT = Line::build
     <_begin, _escape<_ssl_session_timeout>, _space, _capture<';'>, _end>();
+
+
+
+// ------------------------- implementation: ----------------------------------
 
 
 auto get_if_missed(const std::string & conf, const Line & LINE,
@@ -271,7 +294,7 @@ auto get_if_missed(const std::string & conf, const Line & LINE,
 
 
 auto delete_if(const std::string & conf, const rgx::regex & rgx,
-               const std::string & val, const bool compare)
+               const std::string & val)
     -> std::string
 {
     std::string ret{};
@@ -282,7 +305,8 @@ auto delete_if(const std::string & conf, const rgx::regex & rgx,
          pos += match.position(0) + match.length(0))
     {
         const std::string value = match.str(match.size() - 1);
-        auto len = match.position(1);
+        auto len = match.position( match.size()>1 ? 1 : 0 );
+        bool compare = !val.empty();
         if (compare && value!=val && value!="'"+val+"'" && value!='"'+val+'"') {
             len = match.position(0) + match.length(0);
         }
@@ -294,7 +318,7 @@ auto delete_if(const std::string & conf, const rgx::regex & rgx,
 }
 
 
-void add_ssl_directives_to(const std::string & name, const bool isdefault)
+inline void add_ssl_directives_to(const std::string & name, const bool isdefault)
 {
     const std::string prefix = std::string{CONF_DIR} + name;
 
@@ -306,7 +330,7 @@ void add_ssl_directives_to(const std::string & name, const bool isdefault)
         rgx::regex_search(pos, const_conf.end(), match, NGX_SERVER_NAME.RGX());
         pos += match.position(0) + match.length(0))
     {
-        if (match.str(2).find(name) == std::string::npos) { continue; }
+        if (match.str(2).find(name) == std::string::npos) { continue; } //else:
 
         const std::string indent = match.str(1);
 
@@ -346,7 +370,7 @@ void add_ssl_directives_to(const std::string & name, const bool isdefault)
     auto errmsg = std::string{"add_ssl_directives_to error: "};
     errmsg += "cannot add SSL directives to " + name + ".conf, missing: ";
     errmsg += NGX_SERVER_NAME.STR(name, "\n    ") + "\n";
-    throw std::runtime_error(errmsg.c_str());
+    throw std::runtime_error(errmsg);
 }
 
 
@@ -392,19 +416,17 @@ inline auto get_nonce(const T salt=0) -> T
 }
 
 
-void create_ssl_certificate(const std::string & crtpath,
-                            const std::string & keypath,
-                            const int days)
+inline void create_ssl_certificate(const std::string & crtpath,
+                                   const std::string & keypath,
+                                   const int days=792)
 {
     size_t nonce = 0;
 
     try { nonce = get_nonce(nonce); }
 
     catch (...) { // the address of a variable should be random enough:
-        auto addr = &crtpath;
-        auto addrptr = static_cast<const size_t *>(
-                        static_cast<const void *>(&addr) );
-        nonce += *addrptr;
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) sic:
+        nonce += reinterpret_cast<size_t>(&crtpath);
     }
 
     auto noncestr = num2hex(nonce);
@@ -455,49 +477,34 @@ void create_ssl_certificate(const std::string & crtpath,
         perror(errmsg.c_str());
     }
 
+    std::cerr<<"Created self-signed SSL certificate '"<<crtpath;
+    std::cerr<<"' with key '"<<keypath<<"'.\n";
 }
 
 
-void use_cron_to_recreate_certificate(const std::string & name)
+auto check_ssl_certificate(const std::string & crtpath,
+                           const std::string & keypath) -> bool
 {
-    static const char * filename = "/etc/crontabs/root";
-
-    std::string conf{};
-    try { conf = read_file(filename); }
-    catch (const std::ifstream::failure &) { /* is ok if not found, create. */ }
-
-    const std::string add = get_if_missed(conf, CRON_CMD, name);
-
-    if (add.length() > 0) {
-#ifndef NO_UBUS
-        auto service = ubus::call("service","list",UBUS_TIMEOUT).filter("cron");
-
-        if (!service) {
-            std::string errmsg{"use_cron_to_recreate_certificate error: "};
-            errmsg += "Cron unavailable to re-create the ssl certificate for ";
-            errmsg += name + "\n";
-            throw std::runtime_error(errmsg.c_str());
-        } // else active with or without instances:
-#endif
-
-        write_file(filename, std::string{CRON_INTERVAL}+add, std::ios::app);
-
-#ifndef NO_UBUS
-        call("/etc/init.d/cron", "reload");
-#endif
-
-        std::cerr<<"Rebuild the ssl certificate for '";
-        std::cerr<<name<<"' annually with cron."<<std::endl;
+    { // paths are relative to dir:
+        auto dir = std::string_view{"/etc/nginx"};
+        auto crt_rel = crtpath[0]!='/';
+        auto key_rel = keypath[0]!='/';
+        if ( (crt_rel || key_rel) && (chdir(dir.data()) != 0) )
+        {
+            auto errmsg = std::string{"check_ssl_certificate error: entering "};
+            errmsg += dir;
+            perror(errmsg.c_str());
+            errmsg += " (need to change directory since the given ";
+            errmsg += crt_rel ? "ssl_certificate '"+crtpath : std::string{};
+            errmsg += crt_rel&&key_rel ? "' and " : "";
+            errmsg += key_rel ? "ssl_certificate_key '"+keypath : std::string{};
+            errmsg += crt_rel&&key_rel ? "' are" : "' is a";
+            errmsg += " relative path";
+            errmsg += crt_rel&&key_rel ? "s)" : ")";
+            throw std::runtime_error(errmsg);
+        }
     }
-}
 
-
-void add_ssl_if_needed(const std::string & name)
-{
-    add_ssl_directives_to(name, name==LAN_NAME); // let it throw.
-
-    const auto crtpath = std::string{CONF_DIR} + name + ".crt";
-    const auto keypath = std::string{CONF_DIR} + name + ".key";
     constexpr auto remaining_seconds = (365 + 32)*24*60*60;
     constexpr auto validity_days = 3*(365 + 31);
 
@@ -527,15 +534,188 @@ void add_ssl_if_needed(const std::string & name)
 
     if (!is_valid) { create_ssl_certificate(crtpath, keypath, validity_days); }
 
-    try { use_cron_to_recreate_certificate(name); }
-    catch (...) {
-        std::cerr<<"add_ssl_if_needed warning: ";
-        std::cerr<<"cannot use cron to rebuild certificate for "<<name<<"\n";
+    return is_valid;
+}
+
+
+inline auto add_ssl_to_config(const std::string & name)
+{
+    auto pkg = uci::package{"nginx"}; // let it throw.
+
+    if (!is_enabled(pkg)) {
+        auto errmsg = std::string{"add_ssl error: neither there is a file '"};
+        errmsg += std::string{CONF_DIR} + name + ".conf' nor is UCI config ";
+        errmsg += "activated by:\n\tuci set nginx.global.uci_enable=true";
+        throw std::runtime_error(errmsg);
+    }
+
+    auto sec = pkg[name]; // let it throw.
+
+    struct { std::string crt; std::string key; } ret;
+
+    std::cerr<<"Adding SSL directives to UCI server 'nginx."<<name<<"':\n";
+
+    auto cache = false;
+    auto timeout = false;
+    for (auto opt : sec) {
+
+        if (opt.name()=="ssl_session_cache") { cache = true; continue; } //else:
+
+        if (opt.name()=="ssl_session_timeout") { timeout=true; continue; }
+
+        //else:
+        for (auto itm : opt) {
+
+            if (opt.name()=="ssl_certificate_key") { ret.key = itm.name(); }
+
+            else if (opt.name()=="ssl_certificate") { ret.crt = itm.name(); }
+
+            else if (opt.name()=="listen" || opt.name()==LISTEN_LOCALLY) {
+                static const auto rgx_port =
+                    rgx::regex{R"(^\s*([^:]*:|\[[^]]*\]:)?80(\s|$|;))"};
+                auto val = regex_replace(itm.name(), rgx_port, "$01443 ssl$2");
+                if (val!=itm.name()) {
+                    std::cerr<<"\t"<<opt.name()<<"='"<<val<<"' (replacing)\n";
+                    itm.rename(val.c_str());
+                }
+            }
+        }
+    }
+
+    std::cerr<<"\t"<<MANAGE_SSL<<"='self-signed'\n";
+    sec.set(MANAGE_SSL.data(), "self-signed");
+
+    if (ret.crt.empty()) {
+        ret.crt = std::string{CONF_DIR} + name + ".crt";
+        std::cerr<<"\tssl_certificate='"<<ret.crt<<"'\n";
+        sec.set("ssl_certificate", ret.crt.c_str());
+    }
+
+    if (ret.key.empty()) {
+        ret.key = std::string{CONF_DIR} + name + ".key";
+        std::cerr<<"\tssl_certificate_key='"<<ret.key<<"'\n";
+        sec.set("ssl_certificate_key", ret.key.c_str());
+    }
+
+    if (!cache) {
+        std::cerr<<"\tssl_session_cache='"<<SSL_SESSION_CACHE_ARG(name)<<"'\n";
+        sec.set("ssl_session_cache", SSL_SESSION_CACHE_ARG(name).data());
+    }
+
+    if (!timeout) {
+        std::cerr<<"\tssl_session_timeout='"<<SSL_SESSION_TIMEOUT_ARG<<"'\n";
+        sec.set("ssl_session_timeout", SSL_SESSION_TIMEOUT_ARG.data());
+    }
+
+    sec.commit();
+
+    return ret;
+}
+
+
+void install_cron_job(const Line & CRON_LINE, const std::string & name)
+{
+    static const char * filename = "/etc/crontabs/root";
+
+    std::string conf{};
+    try { conf = read_file(filename); }
+    catch (const std::ifstream::failure &) { /* is ok if not found, create. */ }
+
+    const std::string add = get_if_missed(conf, CRON_LINE, name);
+
+    if (add.length() > 0) {
+#ifndef NO_UBUS
+        if (!ubus::call("service", "list", UBUS_TIMEOUT).filter("cron")) {
+            std::string errmsg{"install_cron_job error: "};
+            errmsg += "Cron unavailable to re-create the ssl certificate";
+            errmsg += (name.empty() ? std::string{"s\n"} : " for '"+name+"'\n");
+            throw std::runtime_error(errmsg);
+        } //else active with or without instances:
+#endif
+
+        auto pre = (conf.length()==0 || conf.back()=='\n' ? "" : "\n");
+        write_file(filename, pre+std::string{CRON_INTERVAL}+add, std::ios::app);
+
+#ifndef NO_UBUS
+        call("/etc/init.d/cron", "reload");
+#endif
+
+        std::cerr<<"Rebuild the self-signed SSL certificate";
+        std::cerr<<(name.empty() ? std::string{"s"} : " for '"+name+"'");
+        std::cerr<<" annually with cron."<<std::endl;
     }
 }
 
 
-void del_ssl_directives_from(const std::string & name, const bool isdefault)
+void add_ssl_if_needed(const std::string & name)
+{
+    const auto legacypath = std::string{CONF_DIR} + name + ".conf";
+    if (access(legacypath.c_str(), R_OK)==0) {
+        add_ssl_directives_to(name, name==LAN_NAME); // let it throw.
+
+        const auto crtpath = std::string{CONF_DIR} + name + ".crt";
+        const auto keypath = std::string{CONF_DIR} + name + ".key";
+        check_ssl_certificate(crtpath, keypath); // let it throw.
+
+        try { install_cron_job(CRON_CMD, name); }
+        catch (...) {
+            std::cerr<<"add_ssl_if_needed warning: cannot use cron to rebuild ";
+            std::cerr<<"the self-signed SSL certificate for "<<name<<"\n";
+        }
+        return;
+    } //else:
+
+    auto paths = add_ssl_to_config(name); // let it throw.
+
+    check_ssl_certificate(paths.crt, paths.key); // let it throw.
+
+    try { install_cron_job(CRON_CHECK); }
+    catch (...) {
+        std::cerr<<"add_ssl_if_needed warning: cannot use cron to rebuild ";
+        std::cerr<<"the self-signed SSL certificates.\n";
+    }
+}
+
+
+void remove_cron_job(const Line & CRON_LINE, const std::string & name)
+{
+    static const char * filename = "/etc/crontabs/root";
+
+    const auto const_conf = read_file(filename);
+
+    bool changed = false;
+    auto conf = std::string{};
+
+    size_t prev = 0;
+    size_t curr = 0;
+    while ((curr=const_conf.find('\n', prev)) != std::string::npos) {
+
+        auto line = const_conf.substr(prev, curr-prev+1);
+
+        if (line==delete_if(line, CRON_LINE.RGX(), name)) {
+            conf += line;
+        } else { changed = true; }
+
+        prev = curr + 1;
+    }
+
+    if (changed) {
+        write_file(filename, conf);
+
+        std::cerr<<"Do not rebuild the self-signed SSL certificate";
+        std::cerr<<(name.empty() ? std::string{"s"} : " for '"+name+"'");
+        std::cerr<<" annually with cron anymore."<<std::endl;
+
+#ifndef NO_UBUS
+        if (ubus::call("service", "list", UBUS_TIMEOUT).filter("cron"))
+        { call("/etc/init.d/cron", "reload"); }
+#endif
+    }
+}
+
+
+inline void del_ssl_directives_from(const std::string & name,
+                                    const bool isdefault)
 {
     const std::string prefix = std::string{CONF_DIR} + name;
 
@@ -566,10 +746,10 @@ void del_ssl_directives_from(const std::string & name, const bool isdefault)
                 : delete_if(conf, NGX_INCLUDE_LAN_SSL_LISTEN.RGX());
 
             const auto crtpath = prefix+".crt";
-            conf = delete_if(conf, NGX_SSL_CRT.RGX(), crtpath, true);
+            conf = delete_if(conf, NGX_SSL_CRT.RGX(), crtpath);
 
             const auto keypath = prefix+".key";
-            conf = delete_if(conf, NGX_SSL_KEY.RGX(), keypath, true);
+            conf = delete_if(conf, NGX_SSL_KEY.RGX(), keypath);
 
             conf = delete_if(conf, NGX_SSL_SESSION_CACHE.RGX());
 
@@ -586,48 +766,83 @@ void del_ssl_directives_from(const std::string & name, const bool isdefault)
     auto errmsg = std::string{"del_ssl_directives_from error: "};
     errmsg += "cannot delete SSL directives from " + name + ".conf, missing: ";
     errmsg += NGX_SERVER_NAME.STR(name, "\n    ") + "\n";
-    throw std::runtime_error(errmsg.c_str());
+    throw std::runtime_error(errmsg);
 }
 
 
-void del_ssl(const std::string & name)
+inline auto del_ssl_from_config(const std::string & name)
 {
-    static const char * filename = "/etc/crontabs/root";
+    auto pkg = uci::package{"nginx"}; // let it throw.
 
-    try {
-        const auto const_conf = read_file(filename);
+    if (!is_enabled(pkg)) {
+        auto errmsg = std::string{"del_ssl error: neither there is a file '"};
+        errmsg += std::string{CONF_DIR} + name + ".conf' nor is UCI config ";
+        errmsg += "activated by:\n\tuci set nginx.global.uci_enable=true";
+        throw std::runtime_error(errmsg);
+    }
 
-        bool changed = false;
-        auto conf = std::string{};
+    auto sec = pkg[name]; // let it throw.
 
-        size_t prev = 0;
-        size_t curr = 0;
-        while ((curr=const_conf.find('\n', prev)) != std::string::npos) {
+    struct { std::string crt; std::string key; } ret;
 
-            auto line = const_conf.substr(prev, curr-prev+1);
+    std::cerr<<"Deleting SSL directives from UCI server 'nginx."<<name<<"':\n";
 
-            if (line==delete_if(line,CRON_CMD.RGX(),std::string{name},true)) {
-                conf += line;
-            } else { changed = true; }
+    auto manage = false;
+    for (auto opt : sec) {
 
-            prev = curr + 1;
+        for (auto itm : opt) {
+
+            if (opt.name()=="ssl_certificate_key") { ret.key = itm.name(); }
+
+            else if (opt.name()=="ssl_certificate") { ret.crt = itm.name(); }
+
+            else if ( opt.name()=="ssl_session_cache" ||
+                      opt.name()=="ssl_session_timeout" )
+            {}
+
+            else if (opt.name()==MANAGE_SSL && itm.name()=="self-signed")
+            { manage = true; }
+
+            else if (opt.name()=="listen" || opt.name()==LISTEN_LOCALLY) {
+                static const auto rgx_port = rgx::regex
+                    {R"(^\s*([^:]*:|\[[^]]*\]:)?443(\s.*)?\sssl(\s|$|;))"};
+                auto val = regex_replace(itm.name(), rgx_port, "$0180$2$3");
+                if (val!=itm.name()) {
+                    std::cerr<<"\t"<<opt.name()<<" (set back to '"<<val<<"')\n";
+                    itm.rename(val.c_str());
+                }
+                continue; /* not deleting opt, look at other itm : opt */
+            }
+
+            else { continue; /* not deleting opt, look at other itm : opt */ }
+
+            // Delete matching opt (not skipped by continue):
+            std::cerr<<"\t"<<opt.name()<<" (was '"<<itm.name()<<"')\n";
+            opt.del();
+            break;
         }
+    }
+    if (manage) {
+        sec.commit();
+        return ret;
+    } //else:
 
-        if (changed) {
-            write_file(filename, conf);
+    auto errmsg = std::string{"del_ssl error: not changing the config without"};
+    errmsg += ": uci set nginx."+name+"."+MANAGE_SSL.data()+"='self-signed'";
+    throw std::runtime_error(errmsg);
+}
 
-            std::cerr<<"Do not rebuild the ssl certificate for '";
-            std::cerr<<name<<"' annually with cron anymore."<<std::endl;
 
-#ifndef NO_UBUS
-            if (ubus::call("service", "list", UBUS_TIMEOUT).filter("cron"))
-            { call("/etc/init.d/cron", "reload"); }
-#endif
-        }
+auto del_ssl_legacy(const std::string & name) -> bool
+{
+    const auto legacypath = std::string{CONF_DIR} + name + ".conf";
 
-    } catch (...) {
-        std::cerr<<"del_ssl warning: ";
-        std::cerr<<"cannot delete cron job for "<<name<<" in "<<filename<<"\n";
+    if (access(legacypath.c_str(), R_OK)!=0) { return false; }
+
+    try { remove_cron_job(CRON_CMD, name); }
+    catch (...) {
+        std::cerr<<"del_ssl warning: cannot remove cron job rebuilding ";
+        std::cerr<<"the self-signed SSL certificate for "<<name<<"\n";
     }
 
     try { del_ssl_directives_from(name, name==LAN_NAME); }
@@ -637,19 +852,102 @@ void del_ssl(const std::string & name)
         throw;
     }
 
-    const auto crtpath = std::string{CONF_DIR} + name + ".crt";
+    return true;
+}
+
+
+void del_ssl(const std::string & name)
+{
+    auto crtpath = std::string{};
+    auto keypath = std::string{};
+
+    if (del_ssl_legacy(name)) { //let it throw.
+        crtpath = std::string{CONF_DIR} + name + ".crt";
+        keypath = std::string{CONF_DIR} + name + ".key";
+    }
+
+    else {
+        auto paths = del_ssl_from_config(name); //let it throw.
+        crtpath = paths.crt;
+        keypath = paths.key;
+    }
 
     if (remove(crtpath.c_str())!=0) {
         auto errmsg = "del_ssl warning: cannot remove "+crtpath;
         perror(errmsg.c_str());
     }
 
-    const auto keypath = std::string{CONF_DIR} + name + ".key";
-
     if (remove(keypath.c_str())!=0) {
         auto errmsg = "del_ssl warning: cannot remove "+keypath;
         perror(errmsg.c_str());
     }
+}
+
+
+auto check_ssl(const uci::package & pkg, bool is_enabled) -> bool
+{
+    auto are_valid = true;
+    auto is_enabled_and_at_least_one_has_manage_ssl = false;
+
+    if (is_enabled) {
+        for (auto sec : pkg) {
+            if (sec.anonymous() || sec.type()!="server") { continue; } //else:
+
+            const auto legacypath = std::string{CONF_DIR}+sec.name()+".conf";
+            if (access(legacypath.c_str(), R_OK)==0) { continue; } //else:
+
+            auto keypath = std::string{};
+            auto crtpath = std::string{};
+            auto self_signed = false;
+
+            for (auto opt : sec) {
+                for (auto itm : opt) {
+
+                    if (opt.name()=="ssl_certificate_key")
+                    { keypath = itm.name(); }
+
+                    else if (opt.name()=="ssl_certificate")
+                    { crtpath = itm.name();}
+
+                    else if (opt.name()==MANAGE_SSL) {
+                        if (itm.name()=="self-signed") { self_signed = true; }
+
+                        // else if (itm.name()=="???") { /* manage other */ }
+
+                        else { continue; } // no supported manage_ssl string.
+
+                        is_enabled_and_at_least_one_has_manage_ssl = true;
+                    }
+                }
+            }
+
+            if (self_signed && !crtpath.empty() && !keypath.empty()) {
+                try {
+                    if (!check_ssl_certificate(crtpath, keypath))
+                    { are_valid = false; }
+                }
+                catch (...) {
+                    std::cerr<<"check_ssl warning: cannot build certificate '";
+                    std::cerr<<crtpath<<"' or key '"<<keypath<<"'.\n";
+                }
+            }
+        }
+    }
+
+    auto suffix = std::string_view
+        {" the cron job checking the managed SSL certificates.\n"};
+
+    if (is_enabled_and_at_least_one_has_manage_ssl) {
+        try { install_cron_job(CRON_CHECK); }
+        catch (...) { std::cerr<<"check_ssl warning: cannot install"<<suffix; }
+    }
+
+    else if(access("/etc/crontabs/root", R_OK) == 0) {
+        try { remove_cron_job(CRON_CHECK); }
+        catch (...) { std::cerr<<"check_ssl warning: cannot remove"<<suffix; }
+    } //else: do nothing
+
+    return are_valid;
 }
 
 

--- a/net/nginx-util/src/nginx-util.cpp
+++ b/net/nginx-util/src/nginx-util.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "nginx-util.hpp"
 
 #ifndef NO_SSL
@@ -5,105 +7,266 @@
 #endif
 
 
-void create_lan_listen()
-{
-    std::string listen = "# This file is re-created if Nginx starts or"
-                    " a LAN address changes.\n";
-    std::string listen_default = listen;
-    std::string ssl_listen = listen;
-    std::string ssl_listen_default = listen;
+static auto constexpr file_comment_auto_created = std::string_view
+    {"# This file is re-created when Nginx starts or a local IP is changed.\n"};
 
-    auto add_listen = [&listen, &listen_default
-#ifndef NO_SSL
-                       ,&ssl_listen, &ssl_listen_default
+
+// TODO(pst) replace it with blobmsg_get_string if upstream takes const:
+#ifndef NO_UBUS
+static inline auto _pst_get_string(const blob_attr *attr) -> char *
+{ return static_cast<char *>(blobmsg_data(attr)); }
 #endif
-                      ]
-        (const std::string &pre, const std::string &ip, const std::string &suf)
-        -> void
-    {
-        if (ip.empty()) { return; }
-        const std::string val = pre + ip + suf;
-        listen += "\tlisten " + val + ":80;\n";
-        listen_default += "\tlisten " + val + ":80 default_server;\n";
-#ifndef NO_SSL
-        ssl_listen += "\tlisten " + val + ":443 ssl;\n";
-        ssl_listen_default += "\tlisten " + val + ":443 ssl default_server;\n";
-#endif
-    };
+
+
+auto create_lan_listen() -> std::vector<std::string>
+{
+    std::vector<std::string> ips;
 
 #ifndef NO_UBUS
     try {
         auto loopback_status=ubus::call("network.interface.loopback", "status");
 
-        for (auto ip : loopback_status.filter("ipv4-address", "", "address")) {
-            add_listen("",  static_cast<const char *>(blobmsg_data(ip)), "");
-        }
+        for (auto ip : loopback_status.filter("ipv4-address", "", "address"))
+        { ips.emplace_back(_pst_get_string(ip)); }
 
-        for (auto ip : loopback_status.filter("ipv6-address", "", "address")) {
-            add_listen("[", static_cast<const char *>(blobmsg_data(ip)), "]");
-        }
+        for (auto ip : loopback_status.filter("ipv6-address", "", "address"))
+        { ips.emplace_back(std::string{"["} + _pst_get_string(ip) + "]"); }
+
     } catch (const std::runtime_error &) { /* do nothing about it */ }
 
     try {
         auto lan_status = ubus::call("network.interface.lan", "status");
 
-        for (auto ip : lan_status.filter("ipv4-address", "", "address")) {
-            add_listen("",  static_cast<const char *>(blobmsg_data(ip)), "");
-        }
+        for (auto ip : lan_status.filter("ipv4-address", "", "address"))
+        { ips.emplace_back(_pst_get_string(ip)); }
 
-        for (auto ip : lan_status.filter("ipv6-address", "", "address")) {
-            add_listen("[", static_cast<const char *>(blobmsg_data(ip)), "]");
-        }
+        for (auto ip : lan_status.filter("ipv6-address", "", "address"))
+        { ips.emplace_back(std::string{"["} + _pst_get_string(ip) + "]"); }
 
-        for (auto ip : lan_status.filter("ipv6-prefix-assignment", "", 
+        for (auto ip : lan_status.filter("ipv6-prefix-assignment", "",
             "local-address", "address"))
-        {
-            add_listen("[", static_cast<const char *>(blobmsg_data(ip)), "]");
-        }
+        { ips.emplace_back(std::string{"["} + _pst_get_string(ip) + "]"); }
+
     } catch (const std::runtime_error &) { /* do nothing about it */ }
 #else
-    add_listen("", "127.0.0.1", "");
+    ips.emplace_back("127.0.0.1");
 #endif
 
+    std::string listen = std::string{file_comment_auto_created};
+    std::string listen_default = std::string{file_comment_auto_created};
+    for (const auto & ip : ips) {
+        listen += "\tlisten " + ip + ":80;\n";
+        listen_default += "\tlisten " + ip + ":80 default_server;\n";
+    }
     write_file(LAN_LISTEN, listen);
     write_file(LAN_LISTEN_DEFAULT, listen_default);
+
 #ifndef NO_SSL
+    std::string ssl_listen = std::string{file_comment_auto_created};
+    std::string ssl_listen_default = std::string{file_comment_auto_created};
+    for (const auto & ip : ips) {
+        ssl_listen += "\tlisten " + ip + ":443 ssl;\n";
+        ssl_listen_default += "\tlisten " + ip + ":443 ssl default_server;\n";
+    }
     write_file(LAN_SSL_LISTEN, ssl_listen);
     write_file(LAN_SSL_LISTEN_DEFAULT, ssl_listen_default);
 #endif
+
+    return ips;
 }
 
 
+inline auto change_if_starts_with(const std::string_view & subject,
+                                   const std::string_view & prefix,
+                                   const std::string_view & substitute,
+                                   const std::string_view & seperator=" \t\n;")
+    -> std::string
+{
+    auto view = subject;
+    view = view.substr(view.find_first_not_of(seperator));
+    if (view.rfind(prefix, 0)==0) {
+        if (view.size()==prefix.size()) { return std::string{substitute}; }
+        view = view.substr(prefix.size());
+        if (seperator.find(view[0])!=std::string::npos) {
+            auto ret = std::string{substitute};
+            ret += view;
+            return ret;
+        }
+    }
+    return std::string{subject};
+}
+
+
+inline auto create_server_conf(const uci::section & sec,
+                               const std::vector<std::string> & ips,
+                               const std::string & indent="") -> std::string
+{
+        auto secname = sec.name();
+
+        auto legacypath = std::string{CONF_DIR} + secname + ".conf";
+        if (access(legacypath.c_str(), R_OK)==0) {
+
+            auto message = std::string{"skipped UCI server 'nginx."} + secname;
+            message += "' as it could conflict with: " + legacypath + "\n";
+
+            //TODO(pst) std::cerr<<"create_server_conf notice: "<<message;
+
+            return indent + "# " + message;
+        } //else:
+
+        auto conf = indent + "server { #see uci show 'nginx." + secname + "'\n";
+
+        for (auto opt : sec) {
+
+            for (auto itm : opt) {
+
+                if (opt.name()==LISTEN_LOCALLY) {
+                    for (const auto & ip : ips) {
+                        conf += indent + "\tlisten ";
+                        conf += ip + ":" + itm.name() + ";\n";
+                    }
+                }
+
+                if (opt.name().rfind("uci_", 0)==0) { continue; }
+                //else: standard opt.name()
+
+                auto val = itm.name();
+
+                if (opt.name()=="error_log")
+                { val = change_if_starts_with(val, "logd", "/proc/self/fd/1"); }
+
+                else if (opt.name()=="access_log")
+                { val = change_if_starts_with(val, "logd", "stderr"); }
+
+                conf += indent + "\t" + opt.name() + " " + itm.name() + ";\n";
+            }
+        }
+
+        conf += indent + "}\n";
+
+        return conf;
+}
+
+
+void init_uci(const uci::package & pkg, const std::vector<std::string> & ips)
+{
+    auto conf = std::string{file_comment_auto_created};
+    auto suffix = std::string{};
+    auto indent = std::string{};
+
+    {
+        const auto tmpl = read_file(std::string{UCI_CONF}+".template");
+
+        const auto uci_http_config = std::string_view{"#UCI_HTTP_CONFIG\n"};
+
+        /* regex needs PCRE or std::regex (only used in SSL version):
+         * #ifndef NO_SSL
+         * rgx::smatch match;
+         * auto rgx_http_config = rgx::regex{R"(^(\s*)"+uci_http_config+")"};
+         * if (rgx::regex_search(tmpl, match, rgx_http_config)) {
+         *      auto pos = tmpl.begin() + match.position(0);
+         *      conf.append(tmpl.begin(), pos);
+         *      indent = match.str(1);
+         *      suffix.assign(pos+match.length(0), tmpl.end());
+         * }
+         * #else
+         */
+        auto pos = tmpl.find(uci_http_config);
+        if (pos != std::string::npos) {
+            const auto index = tmpl.find_last_not_of(" \t", pos-1);
+            const auto before = tmpl.begin() + index + 1;
+            conf.append(tmpl.begin(), before);
+            const auto middle = tmpl.begin() + pos;
+            indent.assign(before, middle);
+            const auto after = middle + uci_http_config.length();
+            suffix.assign(after, tmpl.end());
+        }
+        /*#endif*/
+        else {
+            write_file(VAR_UCI_CONF, tmpl);
+            return;
+        }
+    }
+
+    for (auto sec : pkg) {
+        if (sec.type()==std::string_view{"server"}) {
+            conf += create_server_conf(sec, ips, indent) + "\n";
+        }
+    }
+
+    conf += suffix;
+    write_file(VAR_UCI_CONF, conf);
+}
+
+
+auto is_enabled(const uci::package & pkg) -> bool {
+    for (auto sec : pkg) {
+        if (sec.type()!=std::string_view{"main"}) { continue; }
+        if (sec.name()!=std::string_view{"global"}) { continue; }
+        for (auto opt : sec) {
+            if (opt.name()!="uci_enable") { continue; }
+            for (auto itm : opt) {
+                if (itm) { return true; }
+            }
+        }
+    }
+    return false;
+}
+
+
+/*
+ * ___________main_thread________________|______________thread_1________________
+ *  ips = create_lan_listen()            | config = uci::package("nginx")
+ *  if config_enabled (set in thread_1): | config_enabled = is_enabled(config)
+ *  then init_uci(config, ips)           | check_ssl(config, config_enabled)
+ */
 void init_lan()
 {
     std::exception_ptr ex;
+    std::unique_ptr<uci::package> config;
+    bool config_enabled = false;
+    std::mutex configuring;
 
+    configuring.lock();
+    auto thrd = std::thread([&config, &config_enabled, &configuring, &ex]{
+        try {
+            config = std::make_unique<uci::package>("nginx");
+            config_enabled = is_enabled(*config);
+            configuring.unlock();
 #ifndef NO_SSL
-    auto thrd = std::thread([]{ //&ex
-        try { add_ssl_if_needed(std::string{LAN_NAME}); }
-        catch (...) {
-            std::cerr<<"init_lan notice: no server named "<<LAN_NAME<<std::endl;
-            // not: ex = std::current_exception();
+            check_ssl(*config, config_enabled);
+#endif
+        } catch (...) {
+            std::cerr<<"init_lan error: checking UCI file /etc/config/nginx\n";
+            ex = std::current_exception();
         }
     });
-#endif
 
-    try { create_lan_listen(); }
+    std::vector<std::string> ips;
+    try { ips = create_lan_listen(); }
     catch (...) {
-        std::cerr<<"init_lan error: cannot create LAN listen files"<<std::endl;
+        std::cerr<<"init_lan error: cannot create listen files of local IPs.\n";
         ex = std::current_exception();
     }
 
-#ifndef NO_SSL
-    thrd.join();
-#endif
+    configuring.lock();
+    if (config_enabled) {
+        try { init_uci(*config, ips); }
+        catch (...) {
+            std::cerr<<"init_lan error: cannot create "<<VAR_UCI_CONF<<" from ";
+            std::cerr<<UCI_CONF<<".template using UCI file /etc/config/nginx\n";
+            ex = std::current_exception();
+        }
+    }
 
+    thrd.join();
     if (ex) { std::rethrow_exception(ex); }
 }
 
 
 void get_env()
 {
+    std::cout<<"UCI_CONF="<<"'"<<UCI_CONF<<"'"<<std::endl;
     std::cout<<"NGINX_CONF="<<"'"<<NGINX_CONF<<"'"<<std::endl;
     std::cout<<"CONF_DIR="<<"'"<<CONF_DIR<<"'"<<std::endl;
     std::cout<<"LAN_NAME="<<"'"<<LAN_NAME<<"'"<<std::endl;
@@ -114,7 +277,9 @@ void get_env()
         "'"<<std::endl;
     std::cout<<"SSL_SESSION_TIMEOUT_ARG="<<"'"<<SSL_SESSION_TIMEOUT_ARG<<"'\n";
     std::cout<<"ADD_SSL_FCT="<<"'"<<ADD_SSL_FCT<<"'"<<std::endl;
+    std::cout<<"MANAGE_SSL="<<"'"<<MANAGE_SSL<<"'"<<std::endl;
 #endif
+    std::cout<<"LISTEN_LOCALLY="<<"'"<<LISTEN_LOCALLY<<"'"<<std::endl;
 }
 
 
@@ -127,14 +292,15 @@ auto main(int argc, char * argv[]) -> int
         std::array<std::string_view, 2>{"init_lan", ""},
         std::array<std::string_view, 2>{"get_env", ""},
 #ifndef NO_SSL
-        std::array<std::string_view, 2>{ADD_SSL_FCT, " server_name" },
-        std::array<std::string_view, 2>{"del_ssl", " server_name" },
+        std::array<std::string_view, 2>{ADD_SSL_FCT, "server_name" },
+        std::array<std::string_view, 2>{"del_ssl", "server_name" },
+        std::array<std::string_view, 2>{"check_ssl", "" },
 #endif
     };
 
     try {
 
-        if (argc==2 && args[1]==cmds[0][0]) { init_lan(); }
+        if (argc==2 && args[1]==cmds[0][0]) {init_lan();}
 
         else if (argc==2 && args[1]==cmds[1][0]) { get_env(); }
 
@@ -145,8 +311,11 @@ auto main(int argc, char * argv[]) -> int
         else if (argc==3 && args[1]==cmds[3][0])
         { del_ssl(std::string{args[2]}); }
 
-        else if (argc==2 && args[1]==cmds[3][0])
-        { del_ssl(std::string{LAN_NAME}); }
+        else if (argc==2 && args[1]==cmds[3][0]) //TODO(pst) deprecate
+        { del_ssl_legacy(std::string{LAN_NAME}); }
+
+        else if (argc==2 && args[1]==cmds[4][0])
+        { check_ssl(uci::package{"nginx"}); }
 #endif
 
         else {
@@ -154,15 +323,13 @@ auto main(int argc, char * argv[]) -> int
 #ifdef VERSION
             std::cerr<<"version "<<VERSION<<" ";
 #endif
-            std::cerr<<"with ";
+            std::cerr<<"with libuci, ";
 #ifndef NO_UBUS
-            std::cerr<<"ubus, ";
+            std::cerr<<"libubus, ";
 #endif
 #ifndef NO_SSL
             std::cerr<<"libopenssl, ";
-#ifdef NO_PCRE
-            std::cerr<<"std::regex, ";
-#else
+#ifndef NO_PCRE
             std::cerr<<"PCRE, ";
 #endif
 #endif
@@ -170,8 +337,9 @@ auto main(int argc, char * argv[]) -> int
 
             auto usage = std::string{"usage: "} + *argv + " [";
             for (auto cmd : cmds) {
-                usage += std::string{cmd[0]};
-                usage += std::string{cmd[1]} + "|";
+                usage += cmd[0];
+                if (!cmd[1].empty()) { usage += " "; }
+                usage += std::string{cmd[1]} += "|";
             }
             usage[usage.size()-1] = ']';
             std::cerr<<usage<<std::endl;
@@ -183,9 +351,14 @@ auto main(int argc, char * argv[]) -> int
 
     }
 
-    catch (const std::exception & e) { std::cerr<<e.what()<<std::endl; }
+    catch (const std::exception & e) {
+        std::cerr<<" * "<<*argv<<" "<<e.what()<<"\n";
+    }
 
-    catch (...) { perror("main error"); }
+    catch (...) {
+        std::cerr<<" * * "<<*argv;
+        perror(" main error");
+    }
 
     return 1;
 

--- a/net/nginx-util/src/nginx-util.hpp
+++ b/net/nginx-util/src/nginx-util.hpp
@@ -4,19 +4,26 @@
 #include <array>
 #include <cerrno>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
-#include <iostream>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <unistd.h>
+#include <vector>
 
 #ifndef NO_UBUS
 #include "ubus-cxx.hpp"
 #endif
 
+#include "uci-cxx.hpp"
 
 static constexpr auto NGINX_UTIL = std::string_view{"/usr/bin/nginx-util"};
+
+static constexpr auto VAR_UCI_CONF =std::string_view{"/var/lib/nginx/uci.conf"};
+
+static constexpr auto UCI_CONF = std::string_view{"/etc/nginx/uci.conf"};
 
 static constexpr auto NGINX_CONF = std::string_view{"/etc/nginx/nginx.conf"};
 
@@ -24,9 +31,13 @@ static constexpr auto CONF_DIR = std::string_view{"/etc/nginx/conf.d/"};
 
 static constexpr auto LAN_NAME = std::string_view{"_lan"};
 
+static auto constexpr LISTEN_LOCALLY = std::string_view{"uci_listen_locally"};
+
+static auto constexpr MANAGE_SSL = std::string_view{"uci_manage_ssl"};
+
 static constexpr auto LAN_LISTEN =std::string_view{"/var/lib/nginx/lan.listen"};
 
-static constexpr auto LAN_LISTEN_DEFAULT =
+static constexpr auto LAN_LISTEN_DEFAULT = //TODO(pst) deprecate
     std::string_view{"/var/lib/nginx/lan.listen.default"};
 
 
@@ -45,7 +56,13 @@ template<typename ...S>
 auto call(const std::string & program, S... args) -> pid_t;
 
 
-void create_lan_listen();
+auto create_lan_listen() -> std::vector<std::string>;
+
+
+void init_uci(const uci::package & pkg, const std::vector<std::string> & ips);
+
+
+auto is_enabled(const uci::package & pkg) -> bool;
 
 
 void init_lan();
@@ -61,15 +78,34 @@ void get_env();
 void write_file(const std::string_view & name, const std::string & str,
                 const std::ios_base::openmode flag)
 {
-    std::ofstream file(name.data(), flag);
-    if (!file.good()) {
-        throw std::ofstream::failure(
-            "write_file error: cannot open " + std::string{name});
+    auto tmp = std::string{name};
+
+    if ( (flag & std::ios::ate) == 0 && (flag & std::ios::app) == 0 ) {
+        tmp += ".tmp-XXXXXX";
+        auto fd = mkstemp(&tmp[0]);
+        if (fd==-1 || close(fd)!=0)
+        { throw std::runtime_error("write_file error: cannot access " + tmp); }
     }
 
-    file<<str<<std::flush;
+    try {
+        std::ofstream file(tmp.data(), flag);
+        if (!file.good()) {
+            throw std::ofstream::failure
+                ("write_file error: cannot open " + std::string{tmp});
+        }
 
-    file.close();
+        file<<str<<std::flush;
+
+        file.close();
+    } catch(...) {
+        if (tmp!=name) { remove(tmp.c_str()); } //remove can fail.
+        throw;
+    }
+
+    if (rename(tmp.c_str(), name.data()) != 0) {
+        throw std::runtime_error
+            ("write_file error: cannot move " + tmp + " to " + name.data());
+    }
 }
 
 

--- a/net/nginx-util/src/px5g-openssl.hpp
+++ b/net/nginx-util/src/px5g-openssl.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <unistd.h>
 
+
 static constexpr auto rsa_min_modulus_bits = 512;
 
 using EVP_PKEY_ptr = std::unique_ptr<EVP_PKEY, decltype(&::EVP_PKEY_free)>;
@@ -52,11 +53,20 @@ inline auto print_error(const char * str, const size_t  /*len*/, void * errmsg)
 }
 
 
+// wrapper for clang-tidy:
+inline auto _BIO_new_fp(FILE * stream, const bool use_pem,
+                        const bool close=false) -> BIO *
+{
+    return BIO_new_fp( stream,  //NOLINTNEXTLINE(hicpp-signed-bitwise) macros:
+            (use_pem ? BIO_FP_TEXT : 0) | (close ? BIO_CLOSE : BIO_NOCLOSE) );
+}
+
+
 auto checkend(const std::string & crtpath,
               const time_t seconds, const bool use_pem) -> bool
 {
     BIO * bio = crtpath.empty() ?
-        BIO_new_fp(stdin, BIO_NOCLOSE | (use_pem ? BIO_FP_TEXT : 0)) :
+        _BIO_new_fp(stdin, use_pem) :
         BIO_new_file(crtpath.c_str(), (use_pem ? "r" : "rb"));
 
     X509 * x509 = nullptr;
@@ -71,7 +81,7 @@ auto checkend(const std::string & crtpath,
     if (x509==nullptr) {
         std::string errmsg{"checkend error: unable to load certificate\n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     time_t checktime = time(nullptr) + seconds;
@@ -91,7 +101,7 @@ auto gen_eckey(const int curve) -> EVP_PKEY_ptr
         std::string errmsg{"gen_eckey error: cannot build group for curve id "};
         errmsg += std::to_string(curve) + "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     EC_GROUP_set_asn1_flag(group, OPENSSL_EC_NAMED_CURVE);
@@ -115,18 +125,18 @@ auto gen_eckey(const int curve) -> EVP_PKEY_ptr
         std::string errmsg{"gen_eckey error: cannot build key with curve id "};
         errmsg += std::to_string(curve) + "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     EVP_PKEY_ptr pkey{EVP_PKEY_new(), ::EVP_PKEY_free};
 
-    auto tmp = static_cast<char *>(static_cast<void *>(eckey));
-
-    if (!EVP_PKEY_assign_EC_KEY(pkey.get(), tmp)) {
+    // EVP_PKEY_assign_EC_KEY is a macro casting eckey to char *:
+    //NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    if (!EVP_PKEY_assign_EC_KEY(pkey.get(), eckey)) {
         EC_KEY_free(eckey);
         std::string errmsg{"gen_eckey error: cannot assign EC key to EVP\n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     return pkey;
@@ -139,14 +149,14 @@ auto gen_rsakey(const int keysize, const BN_ULONG exponent) -> EVP_PKEY_ptr
         std::string errmsg{"gen_rsakey error: RSA keysize ("};
         errmsg += std::to_string(keysize) + ") out of range [512..";
         errmsg += std::to_string(OPENSSL_RSA_MAX_MODULUS_BITS) + "]";
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
     auto bignum = BN_new();
 
     if (bignum == nullptr) {
         std::string errmsg{"gen_rsakey error: cannot get big number struct\n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     auto rsa = RSA_new();
@@ -167,18 +177,18 @@ auto gen_rsakey(const int keysize, const BN_ULONG exponent) -> EVP_PKEY_ptr
         errmsg += std::to_string(keysize) + " and exponent ";
         errmsg += std::to_string(exponent) + "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     EVP_PKEY_ptr pkey{EVP_PKEY_new(), ::EVP_PKEY_free};
 
-    auto tmp = static_cast<char *>(static_cast<void *>(rsa));
-
-    if (!EVP_PKEY_assign_RSA(pkey.get(), tmp)) {
+    // EVP_PKEY_assign_RSA is a macro casting rsa to char *:
+    //NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    if (!EVP_PKEY_assign_RSA(pkey.get(), rsa)) {
         RSA_free(rsa);
         std::string errmsg{"gen_rsakey error: cannot assign RSA key to EVP\n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     return pkey;
@@ -190,20 +200,21 @@ void write_key(const EVP_PKEY_ptr & pkey,
 {
     BIO * bio = nullptr;
 
-    if (keypath.empty()) {
-        bio = BIO_new_fp( stdout, BIO_NOCLOSE | (use_pem ? BIO_FP_TEXT : 0) );
+    if (keypath.empty()) { bio = _BIO_new_fp(stdout, use_pem); }
 
-    } else { // BIO_new_file(keypath.c_str(), (use_pem ? "w" : "wb") );
+    else { // BIO_new_file(keypath.c_str(), (use_pem ? "w" : "wb") );
 
         static constexpr auto mask = 0600;
         // auto fd = open(keypath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, mask);
+        // creat has no cloexec, alt. triggers cppcoreguidelines-pro-type-vararg
+        //NOLINTNEXTLINE(android-cloexec-creat)
         auto fd = creat(keypath.c_str(), mask); // the same without va_args.
 
         if (fd >= 0) {
             auto fp = fdopen(fd, (use_pem ? "w" : "wb") );
 
             if (fp != nullptr) {
-                bio = BIO_new_fp(fp, BIO_CLOSE | (use_pem ? BIO_FP_TEXT : 0));
+                bio = _BIO_new_fp(fp, use_pem, true);
                 if (bio == nullptr) { fclose(fp); } // (fp owns fd)
             }
             else { close(fd); }
@@ -216,7 +227,7 @@ void write_key(const EVP_PKEY_ptr & pkey,
         errmsg += keypath.empty() ? "stdout" : keypath;
         errmsg += "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     int len = 0;
@@ -249,7 +260,7 @@ void write_key(const EVP_PKEY_ptr & pkey,
         errmsg += keypath.empty() ? "stdout" : keypath;
         errmsg += "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 }
 
@@ -265,7 +276,7 @@ auto subject2name(const std::string & subject) -> X509_NAME_ptr
     if (!name) {
         std::string errmsg{"subject2name error: cannot create X509 name \n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     if (subject.empty()) { return name; }
@@ -287,19 +298,21 @@ auto subject2name(const std::string & subject) -> X509_NAME_ptr
             if (nid == NID_undef) {
                 // skip unknown entries (silently?).
             } else {
-                auto val = static_cast<const unsigned char *>(
-                                static_cast<const void *>(&subject[prev]) );
+                auto val = // X509_NAME_add_entry_by_NID wants it unsigned:
+                    //NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                    reinterpret_cast<const unsigned char *>(&subject[prev]);
 
                 auto len = i - prev;
 
-                if ( X509_NAME_add_entry_by_NID(name.get(), nid, MBSTRING_ASC,
-                                                  val, len, -1, 0)
+                if ( X509_NAME_add_entry_by_NID(name.get(), nid,
+                        MBSTRING_ASC, //NOLINT(hicpp-signed-bitwise) is macro
+                        val, len, -1, 0)
                     == 0 )
                 {
                     std::string errmsg{"subject2name error: cannot add "};
                     errmsg += "/" + type +"="+ subject.substr(prev, len) +"\n";
                     ERR_print_errors_cb(print_error, &errmsg);
-                    throw std::runtime_error(errmsg.c_str());
+                    throw std::runtime_error(errmsg);
                 }
             }
             chr = '=';
@@ -320,7 +333,7 @@ void selfsigned(const EVP_PKEY_ptr & pkey, const int days,
     if (x509 == nullptr) {
         std::string errmsg{"selfsigned error: cannot create X509 structure\n"};
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 
     auto freeX509_and_throw = [&x509](const std::string & what)
@@ -329,7 +342,7 @@ void selfsigned(const EVP_PKEY_ptr & pkey, const int days,
         std::string errmsg{"selfsigned error: cannot set "};
         errmsg += what + " in X509 certificate\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     };
 
     if (X509_set_version(x509, 2) == 0) { freeX509_and_throw("version"); }
@@ -380,7 +393,7 @@ void selfsigned(const EVP_PKEY_ptr & pkey, const int days,
     }
 
     BIO * bio = crtpath.empty() ?
-        BIO_new_fp(stdout, BIO_NOCLOSE | (use_pem ? BIO_FP_TEXT : 0)) :
+        _BIO_new_fp(stdout, use_pem) :
         BIO_new_file(crtpath.c_str(), (use_pem ? "w" : "wb"));
 
     int len = 0;
@@ -399,7 +412,7 @@ void selfsigned(const EVP_PKEY_ptr & pkey, const int days,
         errmsg += crtpath.empty() ? "stdout" : crtpath;
         errmsg += "\n";
         ERR_print_errors_cb(print_error, &errmsg);
-        throw std::runtime_error(errmsg.c_str());
+        throw std::runtime_error(errmsg);
     }
 }
 

--- a/net/nginx-util/src/px5g.cpp
+++ b/net/nginx-util/src/px5g.cpp
@@ -174,7 +174,7 @@ void eckey(const argv_view & argv)
             if (has_main_option) {
                 throw std::runtime_error
                     ("eckey error: more than one main option");
-            } // else:
+            } //else:
             has_main_option = true;
 
             curve = parse_curve(argv[i]);
@@ -223,7 +223,7 @@ void rsakey(const argv_view & argv)
 
             if (has_main_option) {
                 throw std::runtime_error("rsakey error: more than one keysize");
-            } // else:
+            } //else:
             has_main_option = true;
 
             try {

--- a/net/nginx-util/src/test-nginx-util.sh
+++ b/net/nginx-util/src/test-nginx-util.sh
@@ -1,38 +1,58 @@
-#!/bin/bash
+#!/bin/sh
 
 printf "Initializing tests ...\n"
 
 fakechroot=""
 
-[ -x /usr/bin/fakechroot ] && fakechroot="/usr/bin/fakechroot" \
+[ -x "/usr/bin/fakechroot" ] && fakechroot="/usr/bin/fakechroot" \
 || [ "$(id -u)" -eq 0 ] || { \
     printf "Error: Testing needs fakechroot or whoami=root for chroot."
     return 1
 }
 
-TMPROOT=$(mktemp -d /tmp/test-nginx-util-XXXXXX)
+TMPROOT="$(mktemp -d "/tmp/test-nginx-util-XXXXXX")"
 
-ln -s /bin ${TMPROOT}/bin
+ln -s /bin "${TMPROOT}/bin"
 
-mkdir -p ${TMPROOT}/usr/bin/
+mkdir -p "${TMPROOT}/etc/crontabs/"
 
-cp ./test-nginx-util-root.sh ${TMPROOT}/usr/bin/
+mkdir -p "${TMPROOT}/etc/config/"
+cp "./config-nginx-ssl" "${TMPROOT}/etc/config/nginx"
+
+mkdir -p "${TMPROOT}/etc/nginx/"
+cp "./uci.conf.template" "${TMPROOT}/etc/nginx/uci.conf.template"
+ln -s "${TMPROOT}/var/lib/nginx/uci.conf" "${TMPROOT}/etc/nginx/uci.conf"
+
+mkdir -p "${TMPROOT}/usr/bin/"
+cp "/usr/local/bin/uci" "${TMPROOT}/usr/bin/"
+cp "./test-nginx-util-root.sh" "${TMPROOT}/usr/bin/"
+
 
 
 printf "\n\n******* Testing nginx-ssl-util-noubus *******\n"
 
-cp ./nginx-ssl-util-noubus ${TMPROOT}/usr/bin/nginx-util
+cp "./nginx-ssl-util-noubus" "${TMPROOT}/usr/bin/nginx-util"
 
-${fakechroot} /bin/chroot ${TMPROOT} /bin/sh -c /usr/bin/test-nginx-util-root.sh
-
-echo $?
+"${fakechroot}" /bin/chroot "${TMPROOT}" \
+    /bin/sh -c "/usr/bin/test-nginx-util-root.sh" ||
+{
+    echo "!!! Error: $?"
+    rm -r "${TMPROOT}"
+    exit 1
+}
 
 
 printf "\n\n******* Testing nginx-ssl-util-nopcre-noubus *******\n"
 
-cp ./nginx-ssl-util-nopcre-noubus ${TMPROOT}/usr/bin/nginx-util
+cp "./nginx-ssl-util-nopcre-noubus" "${TMPROOT}/usr/bin/nginx-util"
 
-${fakechroot} /bin/chroot ${TMPROOT} /bin/sh -c /usr/bin/test-nginx-util-root.sh
+"${fakechroot}" /bin/chroot "${TMPROOT}" \
+    /bin/sh -c "/usr/bin/test-nginx-util-root.sh" ||
+{
+    echo "!!! Error: $?"
+    rm -r "${TMPROOT}"
+    exit 1
+}
 
 
-rm -r ${TMPROOT}
+rm -r "${TMPROOT}"

--- a/net/nginx-util/src/test-px5g.sh
+++ b/net/nginx-util/src/test-px5g.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PRINT_PASSED=2
 
@@ -8,7 +8,7 @@ OPENSSL_PEM="$(mktemp)"
 OPENSSL_DER="$(mktemp)"
 
 NONCE=$(dd if=/dev/urandom bs=1 count=4 2>/dev/null | hexdump -e '1/1 "%02x"')
-SUBJECT=/C="ZZ"/ST="Somewhere"/L="None"/O="OpenWrt'$NONCE'"/CN="OpenWrt"
+SUBJECT="/C=ZZ/ST=Somewhere/L=None/O=OpenWrt'$NONCE'/CN=OpenWrt"
 
 openssl req -x509 -nodes -days 1 -keyout /dev/null 2>/dev/null \
     -out "$OPENSSL_PEM" -subj "$SUBJECT" \
@@ -18,9 +18,9 @@ openssl req -x509 -nodes -days 1 -keyout /dev/null 2>/dev/null \
 || ( printf "error: generating DER certificate with openssl"; return 1)
 
 
-function test() {
+test() {
     eval "$1 >/dev/null "
-    if [ $? -eq $2 ]
+    if [ $? -eq "$2" ]
     then
         [ "${PRINT_PASSED}" -gt 0 ] \
         && printf "%-72s%-1s\n" "$1" ">/dev/null (-> $2?) passed."
@@ -130,8 +130,8 @@ test './px5g selfsigned -newkey rsa:666       | openssl x509 -checkend 0    ' 0
 test './px5g selfsigned -newkey ec            | openssl x509 -checkend 0    ' 0
 test './px5g selfsigned -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 \
       | openssl x509 -checkend 0                                        ' 0
-test './px5g selfsigned -subj $SUBJECT | openssl x509 -noout \
-      -subject -nameopt compat | grep -q subject=$SUBJECT    2>/dev/null' 0
+test './px5g selfsigned -subj "$SUBJECT" | openssl x509 -noout \
+      -subject -nameopt compat | grep -q subject="$SUBJECT" 2>/dev/null' 0
 test './px5g selfsigned -out /dev/null -keyout /proc/self/fd/1 \
       | openssl rsa -check 2>/dev/null                                  ' 0
 

--- a/net/nginx-util/src/ubus-cxx.cpp
+++ b/net/nginx-util/src/ubus-cxx.cpp
@@ -1,0 +1,148 @@
+#include <iostream>
+
+#include "ubus-cxx.hpp"
+
+
+inline void example_for_checking_if_there_is_a_key()
+{
+    if (ubus::call("service", "list").filter("cron")) {
+        std::cout<<"Cron is active (with or without instances) "<<std::endl;
+    }
+}
+
+
+inline void example_for_getting_values()
+{
+    auto lan_status = ubus::call("network.interface.lan", "status");
+    for (auto t : lan_status.filter("ipv6-address", "", "address")) {
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        auto x = const_cast<blob_attr *>(t);
+        std::cout<<"["<<blobmsg_get_string(x)<<"] ";
+    }
+    for (auto t : lan_status.filter("ipv4-address", "").filter("address")) {
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        auto x = const_cast<blob_attr *>(t);
+        std::cout<<blobmsg_get_string(x)<<" ";
+    }
+    std::cout<<std::endl;
+}
+
+
+inline void example_for_sending_message()
+{
+    auto set_arg = [](blob_buf * buf) -> int
+        { return blobmsg_add_string(buf, "config", "nginx"); };
+    for (auto t : ubus::call("uci", "get", set_arg).filter("values")) {
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        auto x = const_cast<blob_attr *>(t);
+        std::cout<<blobmsg_get_string(x)<<"\n";
+    }
+}
+
+
+inline void example_for_exploring()
+{
+    ubus::strings keys{"ipv4-address", "", ""};
+    for (auto t : ubus::call("network.interface.lan", "status").filter(keys)) {
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        auto x = const_cast<blob_attr *>(t);
+        std::cout<<blobmsg_name(x)<<": ";
+        switch (blob_id(x)) {
+            case BLOBMSG_TYPE_UNSPEC: std::cout<<"[unspecified]"; break;
+            case BLOBMSG_TYPE_ARRAY: std::cout<<"[array]"; break;
+            case BLOBMSG_TYPE_TABLE: std::cout<<"[table]"; break;
+            case BLOBMSG_TYPE_STRING: std::cout<<blobmsg_get_string(x); break;
+            case BLOBMSG_TYPE_INT64: std::cout<<blobmsg_get_u64(x); break;
+            case BLOBMSG_TYPE_INT32: std::cout<<blobmsg_get_u32(x); break;
+            case BLOBMSG_TYPE_INT16: std::cout<<blobmsg_get_u16(x); break;
+            case BLOBMSG_TYPE_BOOL: std::cout<<blobmsg_get_bool(x); break;
+            case BLOBMSG_TYPE_DOUBLE: std::cout<<blobmsg_get_double(x); break;
+            default: std::cout<<"[unknown]";
+        }
+        std::cout<<std::endl;
+    }
+}
+
+
+inline void example_for_recursive_exploring()
+{ // output like from the original ubus call:
+    const auto explore = [](auto message) -> void
+    {
+        auto end = message.end();
+        auto explore_internal =
+            [&end](auto & explore_ref, auto it, size_t depth=1) -> void
+        {
+            std::cout<<std::endl;
+            bool first = true;
+            for (; it!=end; ++it) {
+                //NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                auto attr = const_cast<blob_attr *>(*it);
+                if (first) { first = false; }
+                else { std::cout<<",\n"; }
+                std::cout<<std::string(depth, '\t');
+                std::string name = blobmsg_name(attr);
+                if (!name.empty()) {  std::cout<<"\""<<name<<"\": "; }
+                switch (blob_id(attr)) {
+                    case BLOBMSG_TYPE_UNSPEC: std::cout<<"(unspecified)"; break;
+                    case BLOBMSG_TYPE_ARRAY:
+                        std::cout<<"[";
+                        explore_ref(explore_ref, ubus::iterator{attr}, depth+1);
+                        std::cout<<"\n"<<std::string(depth, '\t')<<"]";
+                        break;
+                    case BLOBMSG_TYPE_TABLE:
+                        std::cout<<"{";
+                        explore_ref(explore_ref, ubus::iterator{attr}, depth+1);
+                        std::cout<<"\n"<<std::string(depth, '\t')<<"}";
+                        break;
+                    case BLOBMSG_TYPE_STRING:
+                        std::cout<<"\""<<blobmsg_get_string(attr)<<"\"";
+                        break;
+                    case BLOBMSG_TYPE_INT64:
+                        std::cout<<blobmsg_get_u64(attr);
+                        break;
+                    case BLOBMSG_TYPE_INT32:
+                        std::cout<<blobmsg_get_u32(attr);
+                        break;
+                    case BLOBMSG_TYPE_INT16:
+                        std::cout<<blobmsg_get_u16(attr);
+                        break;
+                    case BLOBMSG_TYPE_BOOL:
+                        std::cout<<(blobmsg_get_bool(attr) ? "true" : "false");
+                        break;
+                    case BLOBMSG_TYPE_DOUBLE:
+                        std::cout<<blobmsg_get_double(attr);
+                        break;
+                    default: std::cout<<"(unknown)"; break;
+                }
+            }
+        };
+        std::cout<<"{";
+        explore_internal(explore_internal, message.begin());
+        std::cout<<"\n}"<<std::endl;
+    };
+    explore(ubus::call("network.interface.lan", "status"));
+}
+
+
+auto main() -> int {
+
+    try {
+        example_for_checking_if_there_is_a_key();
+
+        example_for_getting_values();
+
+        example_for_sending_message();
+
+        example_for_exploring();
+
+        example_for_recursive_exploring();
+
+        return 0;
+    }
+
+    catch (const std::exception & e) { std::cerr<<e.what()<<std::endl; }
+
+    catch (...) { perror("main error"); }
+
+    return 1;
+}

--- a/net/nginx-util/src/uci-cxx.cpp
+++ b/net/nginx-util/src/uci-cxx.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "uci-cxx.hpp"
+
+
+auto main() -> int {
+
+    uci::element p = uci::package{"nginx"};
+    std::cout<<"package "<<p.name()<<"\n\n";
+    for (auto s : p) {
+        std::cout<<"config "<<s.type()<<" '"<<s.name()<<"'\n";
+        for (auto o : s) {
+            for (auto i : o) {
+                std::cout<<"\t"<<o.type()<<" "<<o.name()<<" '"<<i.name()<<"'\n";
+            }
+        }
+        std::cout<<"\n";
+    }
+
+}

--- a/net/nginx-util/src/uci-cxx.hpp
+++ b/net/nginx-util/src/uci-cxx.hpp
@@ -1,0 +1,510 @@
+#ifndef _UCI_CXX_HPP
+#define _UCI_CXX_HPP
+
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <uci.h>
+
+
+namespace uci {
+
+
+
+template<class T>
+class iterator { // like uci_foreach_element_safe.
+
+private:
+
+    const uci_ptr & _ptr;
+
+    uci_element * _it = nullptr;
+
+    uci_element * _next = nullptr;
+
+    // wrapper for clang-tidy
+    inline auto _list_to_element(const uci_list * cur) -> uci_element * {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        return list_to_element(cur); // macro casting container=pointer-offset.
+    }
+
+
+public:
+
+    inline explicit iterator(const uci_ptr & ptr, const uci_list * cur)
+    : _ptr{ptr}, _it{_list_to_element(cur)}
+    { _next = _list_to_element(_it->list.next); }
+
+
+    inline iterator(iterator &&) noexcept = default;
+
+
+    inline iterator(const iterator &) = delete;
+
+
+    inline auto operator=(const iterator &) -> iterator & = delete;
+
+
+    inline auto operator=(iterator &&) -> iterator & = delete;
+
+
+    auto operator*() -> T { return T{_ptr, _it}; }
+
+
+    inline auto operator!=(const iterator & rhs) -> bool
+    { return (&_it->list != &rhs._it->list); }
+
+
+    inline auto operator++() -> iterator &
+    {
+        _it = _next;
+        _next = _list_to_element(_next->list.next);
+        return *this;
+    }
+
+
+    inline ~iterator() = default;
+
+};
+
+
+
+class locked_context {
+
+private:
+
+    static std::mutex inuse;
+
+
+public:
+
+    inline locked_context() { inuse.lock(); }
+
+    inline locked_context(locked_context &&) noexcept = default;
+
+    inline locked_context(const locked_context &) = delete;
+
+    inline auto operator=(const locked_context &) -> locked_context & = delete;
+
+    inline auto operator=(locked_context &&) -> locked_context & = delete;
+
+
+    //NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    inline auto get() -> uci_context * // is member to enforce inuse
+    {
+        static auto free_ctx = [](uci_context * ctx) { uci_free_context(ctx); };
+        static std::unique_ptr<uci_context, decltype(free_ctx)>
+            lazy_ctx{uci_alloc_context(), free_ctx};
+
+        if (!lazy_ctx) { // it could be available on a later call:
+            lazy_ctx.reset(uci_alloc_context());
+            if (!lazy_ctx) {
+                throw std::runtime_error("uci error: cannot allocate context");
+            }
+        }
+
+        return lazy_ctx.get();
+    }
+
+
+    inline ~locked_context() { inuse.unlock(); }
+
+};
+
+
+
+template<class T>
+class element {
+
+private:
+
+    uci_list * _begin = nullptr;
+
+    uci_list * _end = nullptr;
+
+    uci_ptr _ptr{};
+
+
+protected:
+
+    [[nodiscard]] inline auto ptr() -> uci_ptr & { return _ptr; }
+
+
+    [[nodiscard]] inline auto ptr() const -> const uci_ptr & { return _ptr; }
+
+
+    void init_begin_end(uci_list * begin, uci_list * end)
+    {
+        _begin = begin;
+        _end = end;
+    }
+
+
+    inline explicit element(const uci_ptr & pre, uci_element * last)
+    : _ptr{pre} { _ptr.last = last; }
+
+
+    inline explicit element() = default;
+
+
+public:
+
+    inline element(element &&) noexcept = default;
+
+
+    inline element(const element &) = delete;
+
+
+    inline auto operator=(const element &) -> element & = delete;
+
+
+    inline auto operator=(element &&) -> element & = delete;
+
+
+    auto operator[](std::string_view key) const -> T;
+
+
+    [[nodiscard]] inline auto name() const -> std::string
+    { return _ptr.last->name; }
+
+
+    void rename(const char * value) const;
+
+
+    void commit() const;
+
+
+    [[nodiscard]] inline auto begin() const -> iterator<T>
+    { return iterator<T>{_ptr, _begin}; }
+
+
+    [[nodiscard]] inline auto end() const -> iterator<T>
+    { return iterator<T>{_ptr, _end}; }
+
+
+    inline ~element() = default;
+
+};
+
+
+class section;
+
+class option;
+
+class item;
+
+
+
+class package : public element<section> {
+
+public:
+
+    inline package(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        ptr().p = uci_to_package(ptr().last); // macro casting pointer-offset.
+        ptr().package = ptr().last->name;
+
+        auto end = &ptr().p->sections;
+        auto begin = end->next;
+        init_begin_end(begin, end);
+    }
+
+
+    explicit package(const char * name);
+
+
+    auto set(const char * key, const char * type) const -> section;
+
+};
+
+
+
+class section : public element<option> {
+
+public:
+
+    inline section(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        ptr().s = uci_to_section(ptr().last); // macro casting pointer-offset.
+        ptr().section = ptr().last->name;
+
+        auto end = &ptr().s->options;
+        auto begin = end->next;
+        init_begin_end(begin, end);
+    }
+
+
+    auto set(const char * key, const char * value) const -> option;
+
+
+    void del();
+
+
+    [[nodiscard]] inline auto anonymous() const -> bool
+    { return ptr().s->anonymous; }
+
+
+    [[nodiscard]] inline auto type() const -> std::string
+    { return ptr().s->type; }
+
+};
+
+
+
+class option : public element<item> {
+
+public:
+
+    inline option(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        ptr().o = uci_to_option(ptr().last); // macro casting pointer-offset.
+        ptr().option = ptr().last->name;
+
+        if (ptr().o->type==UCI_TYPE_LIST) { // use union ptr().o->v as list:
+            //NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+            auto end = &ptr().o->v.list;
+            auto begin = end->next;
+            init_begin_end(begin, end);
+        } else {
+            auto begin = &ptr().last->list;
+            auto end = begin->next;
+            init_begin_end(begin, end);
+        }
+    }
+
+
+    void del();
+
+
+    [[nodiscard]] inline auto type() const -> std::string
+    { return (ptr().o->type==UCI_TYPE_LIST ? "list" : "option"); }
+
+};
+
+
+
+class item : public element<item> {
+
+public:
+
+    inline item(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    { ptr().value = ptr().last->name; }
+
+
+    [[nodiscard]] inline auto type() const -> std::string
+    { return (ptr().o->type==UCI_TYPE_LIST ? "list" : "option"); }
+
+
+    [[nodiscard]] inline auto name() const -> std::string
+    {
+        return ( ptr().last->type==UCI_TYPE_ITEM ? ptr().last->name :
+                 //else: use union ptr().o->v as string:
+                 //NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+                 ptr().o->v.string );
+    }
+
+
+    inline explicit operator bool() const
+    {
+        const auto x = std::string_view{name()};
+
+        if (x=="0" || x=="off" || x=="false" || x=="no" || x=="disabled")
+        { return false; }
+
+        if (x=="1" || x=="on" || x=="true" || x=="yes" || x=="enabled")
+        { return true; }
+
+        auto errmsg = std::string{"uci_error: item is not bool "} + name();
+        throw std::runtime_error(errmsg.c_str());
+    }
+
+
+    void rename(const char * value) const;
+
+};
+
+
+
+// ------------------------- implementation: ----------------------------------
+
+
+std::mutex locked_context::inuse{};
+
+
+inline auto uci_error(uci_context * ctx, const char * prefix=nullptr)
+    -> std::runtime_error
+{
+    char * errmsg = nullptr;
+    uci_get_errorstr(ctx, &errmsg, prefix);
+
+    std::unique_ptr<char, decltype(&std::free)> auto_free{errmsg, std::free};
+    return std::runtime_error{errmsg};
+}
+
+
+template<class T>
+auto element<T>::operator[](std::string_view key) const -> T
+{
+    for (auto elmt : *this) { if (elmt.name()==key) { return elmt; } }
+
+    auto errmsg = std::string{"uci error: cannot find "}.append(key);
+    throw uci_error(locked_context{}.get(), errmsg.c_str());
+}
+
+
+template<class T>
+void element<T>::rename(const char * value) const
+{
+    if (value==name()) { return; }
+
+    auto ctx = locked_context{};
+    auto tmp_ptr = uci_ptr{_ptr};
+    tmp_ptr.value = value;
+    if (uci_rename(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot rename "}.append(name());
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+template<class T>
+void element<T>::commit() const
+{
+    auto ctx = locked_context{};
+    // TODO(pst) use when possible:
+    // if (uci_commit(ctx.get(), &_ptr.p, true) != 0) {
+    //    auto errmsg = std::string{"uci error: cannot commit "} + _ptr.package;
+    //    throw uci_error(ctx.get(), errmsg.c_str());
+    // }
+    auto err = uci_save(ctx.get(), _ptr.p);
+    if (err==0) {
+        uci_context * tmp_ctx = uci_alloc_context();
+        err = tmp_ctx==nullptr;
+        uci_package * tmp_pkg = nullptr;
+        if (err==0) { err = uci_load(tmp_ctx, _ptr.package, &tmp_pkg); }
+        if (err==0) { err = uci_commit(tmp_ctx, &tmp_pkg, false); }
+        if (err==0) { err = uci_unload(tmp_ctx, tmp_pkg); }
+        if (tmp_ctx!=nullptr) { uci_free_context(tmp_ctx); }
+    }
+
+    if (err != 0) {
+        auto errmsg = std::string{"uci error: cannot commit "} + _ptr.package;
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+package::package(const char * name)
+{
+    auto ctx = locked_context{};
+
+    auto pkg = uci_lookup_package(ctx.get(), name);
+    if (pkg==nullptr) {
+        if (uci_load(ctx.get(), name, &pkg) != 0) {
+            auto errmsg = std::string{"uci error: cannot load package "} + name;
+            throw uci_error(ctx.get(), errmsg.c_str());
+        }
+    }
+
+    ptr().package = name;
+    ptr().p = pkg;
+    ptr().last = &pkg->e;
+
+    auto end = &ptr().p->sections;
+    auto begin = end->next;
+    init_begin_end(begin, end);
+}
+
+
+auto package::set(const char * key, const char * type) const -> section
+{
+    auto ctx = locked_context{};
+
+    auto tmp_ptr = uci_ptr{ptr()};
+    tmp_ptr.section = key;
+    tmp_ptr.value = type;
+    if (uci_set(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot set section "} + type
+            + "'" + key + "' in package " + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+
+    return section{ptr(), tmp_ptr.last};
+}
+
+
+auto section::set(const char * key, const char * value) const -> option
+{
+    auto ctx = locked_context{};
+
+    auto tmp_ptr = uci_ptr{ptr()};
+    tmp_ptr.option = key;
+    tmp_ptr.value = value;
+    if (uci_set(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot set option "} + key
+            + "'" + value + "' in package " + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+
+    return option{ptr(), tmp_ptr.last};
+}
+
+
+void section::del()
+{
+    auto ctx = locked_context{};
+    if (uci_delete(ctx.get(), &ptr()) != 0) {
+        auto errmsg = std::string{"uci error: cannot delete section "} + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+void option::del()
+{
+    auto ctx = locked_context{};
+    if (uci_delete(ctx.get(), &ptr()) != 0) {
+        auto errmsg = std::string{"uci error: cannot delete option "} + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+void item::rename(const char * value) const
+{
+    if (value==name()) { return; }
+
+    auto ctx = locked_context{};
+    auto tmp_ptr = uci_ptr{ptr()};
+
+    if (tmp_ptr.last->type!=UCI_TYPE_ITEM) {
+        tmp_ptr.value = value;
+        if (uci_set(ctx.get(), &tmp_ptr) != 0) {
+            auto errmsg = std::string{"uci error: cannot rename item "}+name();
+            throw uci_error(ctx.get(), errmsg.c_str());
+        }
+        return;
+    } //else:
+
+    tmp_ptr.value = tmp_ptr.last->name;
+    if (uci_del_list(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot rename (del) "} + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+
+    tmp_ptr.value = value;
+    if (uci_add_list(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot rename (add) "} + value;
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+} // namespace uci
+
+#endif


### PR DESCRIPTION
**tl;dr:** The functions `{add,del}_ssl` modify a server
section of the UCI config if there is no `.conf` file with
the same name in `/etc/nginx/conf.d/`.

Then `init_lan` creates `/var/lib/nginx/uci.conf` files by
copying the `/etc/nginx/uci.conf.template` and standard
options from the UCI config; additionally
`uci_listen_locally` is replaced by `listen` with all local
IPs and the special path `logd` can be used in
`{access,error}_log`.

The init does not change the configuration beside
re-creating self-signed certificates when needed. This is
also the only purpose of the new `check_ssl`, which is
installed as yearly cron job.

**Initialization:**

Invoking `nginx-util init_lan` parses the UCI configuration
for package `nginx`. It creates a server part in
`/var/lib/nginx/uci.conf` for every
`section server '$name'` by copying all UCI options but the
following:

* `option uci_manage_ssl` is skipped. It is set to
'self-signed' by `nginx-util add_ssl $name`, removed by
`nginx-util del_ssl $name` and used by
`nginx-util check_ssl` (see below).

* `list uci_listen_locally '$port ...'`: Is replaced by a
set of directives of the form `listen $ip:$port ...;` using
all local IPs. It can occur more than one time with
different ports.

* `logd` as path in `error_log` or `access_log` writes them
to STDERR respective STDOUT, which are fowarded by Nginx's
init to the log daemon. Specifically:
`option error_log 'logd'` becomes `error_log stderr;` and
`option access_log 'logd openwrt'` becomes
`access_log /proc/self/fd/1 openwrt;`

Other `[option|list] key 'value'` entries just become
`key value;` directives.

The init calls internally also `check_ssl` for rebuilding
self-signed SSL certificates if needed (see below). And it
still sets up `/var/lib/nginx/lan{,_ssl}.listen` files as
it is doing in the current version (so they stay available).

**Defaults:**

The package installs a UCI configuration file
`/etc/config/nginx` with a default server listening on all
local IPs (and one redirecting inexistent URLs to https in
the SSL versions). Furthermore, it includes also a
`/etc/nginx/uci.conf.template` containing the current setup
and a marker, which will be replaced by the created UCI
servers when calling `init_lan`.

**Other:**

If there is a file named `/etc/nginx/conf.d/$name.conf` the
functions `init_lan`, `add_ssl $name` and `del_ssl $name`
will use that file instead of a UCI server section with the
same $name (as it is doing in the current version).

Else if there is only a UCI `section server $name`:
* `nginx-util add_ssl $name` will add to it:
`option uci_manage_ssl 'self-signed'`
`option ssl_certificate '/etc/nginx/conf.d/$name.crt'`
`option ssl_certificate_key '/etc/nginx/conf.d/$name.key'`
`option ssl_session_cache 'shared:SSL:32k'`
`option ssl_session_timeout '64m'`
If these options are already present, they will stay the
same; just the first option `uci_manage_ssl` will always be
changed to 'self-signed'. The command also changes all
`listen` and `uci_listen_locally` list items to use port
443 and ssl instead of port 80. If they stated another port
than 80 before, they are kept the same. Furthermore, it
creates a self-signed SSL certificate if necessary, i.e.,
if there is no *valid* certificate and key at the
locations given by the options `ssl_certificate` and
`ssl_certificate_key`.

* `nginx-util del_ssl $name` checks if `uci_manage_ssl` is
set 'self-signed' in the corresponding UCI section. Only
then it removes all of the above options regardless of the
value looking just at the key name. Then, it also changes
all `listen` and `uci_listen_locally` list items to use
port 80 (without ssl) instead of port 443 with ssl. If
stating another port than 443, they are kept the same.
Furthermore, it removes the SSL certificate and key that
were indicated by `ssl_certificate{,_key}`.

* `nginx-util check_ssl` looks through all server sections
of the UCI config for `uci_manage_ssl 'self-signed'`. On
every hit it checks if the SSL certificate-key-pair
indicated by the options `ssl_certificate{,_key}` is
expired. Then it re-creates a self-signed certificate.
If there exists at least one `section server` with
`uci_manage_ssl 'self-signed'`, it will try to install
itself as cron job. If there are no such sections, it
removes that cron job if possible.

Signed-off-by: Peter Stadler <peter.stadler@student.uibk.ac.at>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
