### PR TITLE
nginx: set log level to crit for luci-static

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.17.10
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/

--- a/net/nginx/files-luci-support/luci.locations
+++ b/net/nginx/files-luci-support/luci.locations
@@ -13,4 +13,5 @@ location ~ /cgi-bin/cgi-(backup|download|upload|exec) {
 }
 
 location /luci-static {
+		error_log stderr crit;
 }


### PR DESCRIPTION
Do not write errors for inexistent files to the system log.

Signed-off-by: Peter Stadler <peter.stadler@student.uibk.ac.at>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
